### PR TITLE
Add event mask option to histograms

### DIFF
--- a/sidm/definitions/hists.py
+++ b/sidm/definitions/hists.py
@@ -146,63 +146,65 @@ hist_defs = {
         [
             h.Axis(hist.axis.Regular(80, 0, 0.8, name="lj_pfIsolation05",
                                      label="Lepton jet isolation"),
-                   lambda objs: objs["ljs"].pfIsolation05),
+                   lambda objs, mask: objs["ljs"].pfIsolation05),
         ],
     ),
     "lj0_pfIsolation05": h.Histogram(
         [
             h.Axis(hist.axis.Regular(80, 0, 0.8, name="lj_pfIsolation05",
                                      label="Leading lepton jet isolation"),
-                   lambda objs: objs["ljs"][ak.num(objs["ljs"]) > 1, 0].pfIsolation05),
+                   lambda objs, mask: objs["ljs"][mask, 0].pfIsolation05),
         ],
+        evt_mask=lambda objs: ak.num(objs["ljs"]) > 0,
     ),
     "lj1_pfIsolation05": h.Histogram(
         [
             h.Axis(hist.axis.Regular(80, 0, 0.8, name="lj_pfIsolation05",
                                      label="Subleading lepton jet isolation"),
-                   lambda objs: objs["ljs"][ak.num(objs["ljs"]) > 1, 1].pfIsolation05),
+                   lambda objs, mask: objs["ljs"][mask, 1].pfIsolation05),
         ],
+        evt_mask=lambda objs: ak.num(objs["ljs"]) > 1,
     ),
     "lj_pfIsolationPtNoPU05": h.Histogram(
         [
             h.Axis(hist.axis.Regular(80, 0, 0.8, name="lj_pfIsolationPtNoPU05",
                                      label="Lepton jet isolation"),
-                   lambda objs: objs["ljs"].pfIsolationPtNoPU05),
+                   lambda objs, mask: objs["ljs"].pfIsolationPtNoPU05),
         ],
     ),
     "lj_pfIsolationPt05": h.Histogram(
         [
             h.Axis(hist.axis.Regular(80, 0, 0.8, name="lj_pfIsolationPt05",
                                      label="Lepton jet isolation"),
-                   lambda objs: objs["ljs"].pfIsolationPt05),
+                   lambda objs, mask: objs["ljs"].pfIsolationPt05),
         ],
     ),
     "lj_pfIsolation07": h.Histogram(
         [
             h.Axis(hist.axis.Regular(80, 0, 0.8, name="lj_pfIsolation07",
                                      label="Lepton jet isolation"),
-                   lambda objs: objs["ljs"].pfIsolation07),
+                   lambda objs, mask: objs["ljs"].pfIsolation07),
         ],
     ),
     "lj_pfIsolationPtNoPU07": h.Histogram(
         [
             h.Axis(hist.axis.Regular(80, 0, 0.8, name="lj_pfIsolationPtNoPU07",
                                      label="Lepton jet isolation"),
-                   lambda objs: objs["ljs"].pfIsolationPtNoPU07),
+                   lambda objs, mask: objs["ljs"].pfIsolationPtNoPU07),
         ],
     ),
     "lj_pfIsolationPt07": h.Histogram(
         [
             h.Axis(hist.axis.Regular(80, 0, 0.8, name="lj_pfIsolationPt07",
                                      label="Lepton jet isolation"),
-                   lambda objs: objs["ljs"].pfIsolationPt07),
+                   lambda objs, mask: objs["ljs"].pfIsolationPt07),
         ],
     ),
     "lj_pfiso": h.Histogram(
         [
             h.Axis(hist.axis.Regular(80, 0, 0.8, name="lj_pfiso",
                                      label="Lepton jet isolation"),
-                   lambda objs: objs["ljs"].pfiso),
+                   lambda objs, mask: objs["ljs"].pfiso),
         ],
     ),
     "lj0_pt": h.Histogram(
@@ -225,14 +227,14 @@ hist_defs = {
         [
             h.Axis(hist.axis.Regular(350, 0, 700, name="lj_e",
                                      label="Leading lepton jet E [GeV]"),
-                   lambda objs: objs["ljs"][ak.num(objs["ljs"]) > 1, 0].p4.energy),
+                   lambda objs, mask: objs["ljs"][ak.num(objs["ljs"]) > 1, 0].p4.energy),
         ],
     ),
     "lj1_e": h.Histogram(
         [
             h.Axis(hist.axis.Regular(350, 0, 700, name="lj_e",
                                      label="Subleading lepton jet E [GeV]"),
-                   lambda objs: objs["ljs"][ak.num(objs["ljs"]) > 1, 1].p4.energy),
+                   lambda objs, mask: objs["ljs"][ak.num(objs["ljs"]) > 1, 1].p4.energy),
         ],
     ),
     "lj_eta_phi": h.Histogram(
@@ -410,12 +412,12 @@ hist_defs = {
         [
             h.Axis(hist.axis.Regular(200, 0, 2*math.pi, name="ljlj_absdphi",
                                      label=fr"Lepton jet pair |$\Delta\phi$|"),
-                   lambda objs: abs(objs["ljs"][ak.num(objs["ljs"]) > 1, 1].p4.phi
-                                    - objs["ljs"][ak.num(objs["ljs"]) > 1, 0].p4.phi)),
+                   lambda objs, mask: abs(objs["ljs"][mask, 1].p4.phi - objs["ljs"][:, 0].p4.phi)),
             h.Axis(hist.axis.Regular(80, 0, 0.8, name="lj_pfIsolationPt05",
                                      label="Leading lepton jet isolation"),
-                   lambda objs: objs["ljs"][ak.num(objs["ljs"]) > 1, 0].pfIsolationPt05),
+                   lambda objs, mask: objs["ljs"][mask, 0].pfIsolationPt05),
         ],
+        evt_mask=lambda objs: ak.num(objs["ljs"]) > 1,
     ),
     # gen
     "gen_abspid": h.Histogram(
@@ -464,7 +466,7 @@ hist_defs = {
         [
             # dR(subleading gen E, leading gen E)
             h.Axis(hist.axis.Regular(50, 0, 1.0, name="genE_genE_dR"),
-                   lambda objs, mask: objs[mask, 1].p4.delta_r(objs["genEs"][mask, 0].p4)),
+                   lambda objs, mask: objs["genEs"][mask, 1].p4.delta_r(objs["genEs"][mask, 0].p4)),
         ],
         evt_mask=lambda objs: ak.num(objs["genEs"]) > 1,
     ),

--- a/sidm/definitions/hists.py
+++ b/sidm/definitions/hists.py
@@ -24,122 +24,122 @@ hist_defs = {
     "pv_n": h.Histogram(
         [
             h.Axis(hist.axis.Regular(50, 0, 100, name="pv_n"),
-                   lambda objs: ak.num(objs["pvs"])),
+                   lambda objs, mask: ak.num(objs["pvs"])),
         ],
     ),
     "pv_ndof": h.Histogram(
         [
             h.Axis(hist.axis.Regular(25, 0, 100, name="pv_ndof"),
-                   lambda objs: objs["pvs"].ndof),
+                   lambda objs, mask: objs["pvs"].ndof),
         ],
     ),
     "pv_z": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, -50, 50, name="pv_z"),
-                   lambda objs: objs["pvs"].z),
+                   lambda objs, mask: objs["pvs"].z),
         ],
     ),
     "pv_rho": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, -0.5, 0.5, name="pv_rho"),
-                   lambda objs: objs["pvs"].rho),
+                   lambda objs, mask: objs["pvs"].rho),
         ],
     ),
     # pfelectron
     "electron_n": h.Histogram(
         [
             h.Axis(hist.axis.Integer(0, 10, name="electron_n"),
-                   lambda objs: ak.num(objs["electrons"])),
+                   lambda objs, mask: ak.num(objs["electrons"])),
         ],
     ),
     "electron_pt": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 200, name="electron_pt"),
-                   lambda objs: objs["electrons"].p4.pt),
+                   lambda objs, mask: objs["electrons"].p4.pt),
         ],
     ),
     "electron_eta_phi": h.Histogram(
         [
             h.Axis(hist.axis.Regular(50, -3, 3, name="electron_eta"),
-                   lambda objs: objs["electrons"].p4.eta),
+                   lambda objs, mask: objs["electrons"].p4.eta),
             h.Axis(hist.axis.Regular(50, -1*math.pi, math.pi, name="electron_phi"),
-                   lambda objs: objs["electrons"].p4.phi),
+                   lambda objs, mask: objs["electrons"].p4.phi),
         ],
     ),
     # pfphoton
     "photon_n": h.Histogram(
         [
             h.Axis(hist.axis.Integer(0, 10, name="photon_n"),
-                   lambda objs: ak.num(objs["photons"])),
+                   lambda objs, mask: ak.num(objs["photons"])),
         ],
     ),
     "photon_pt": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 200, name="photon_pt"),
-                   lambda objs: objs["photons"].p4.pt),
+                   lambda objs, mask: objs["photons"].p4.pt),
         ],
     ),
     "photon_eta_phi": h.Histogram(
         [
             h.Axis(hist.axis.Regular(50, -3, 3, name="photon_eta"),
-                   lambda objs: objs["photons"].p4.eta),
+                   lambda objs, mask: objs["photons"].p4.eta),
             h.Axis(hist.axis.Regular(50, -1*math.pi, math.pi, name="photon_phi"),
-                   lambda objs: objs["photons"].p4.phi),
+                   lambda objs, mask: objs["photons"].p4.phi),
         ],
     ),
     # pfmuon
     "muon_n": h.Histogram(
         [
             h.Axis(hist.axis.Integer(0, 10, name="muon_n"),
-                   lambda objs: ak.num(objs["muons"])),
+                   lambda objs, mask: ak.num(objs["muons"])),
         ],
     ),
     "muon_pt": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 200, name="muon_pt"),
-                   lambda objs: objs["muons"].p4.pt),
+                   lambda objs, mask: objs["muons"].p4.pt),
         ],
     ),
     "muon_eta_phi": h.Histogram(
         [
             h.Axis(hist.axis.Regular(50, -3, 3, name="muon_eta"),
-                   lambda objs: objs["muons"].p4.eta),
+                   lambda objs, mask: objs["muons"].p4.eta),
             h.Axis(hist.axis.Regular(50, -1*math.pi, math.pi, name="muon_phi"),
-                   lambda objs: objs["muons"].p4.phi),
+                   lambda objs, mask: objs["muons"].p4.phi),
         ],
     ),
     # dsamuon
     "dsaMuon_n": h.Histogram(
         [
             h.Axis(hist.axis.Integer(0, 10, name="dsaMuon_n"),
-                   lambda objs: ak.num(objs["dsaMuons"])),
+                   lambda objs, mask: ak.num(objs["dsaMuons"])),
         ],
     ),
     "dsaMuon_pt": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 200, name="dsaMuon_pt"),
-                   lambda objs: objs["dsaMuons"].p4.pt),
+                   lambda objs, mask: objs["dsaMuons"].p4.pt),
         ],
     ),
     "dsaMuon_eta_phi": h.Histogram(
         [
             h.Axis(hist.axis.Regular(50, -3, 3, name="dsaMuon_eta"),
-                   lambda objs: objs["dsaMuons"].p4.eta),
+                   lambda objs, mask: objs["dsaMuons"].p4.eta),
             h.Axis(hist.axis.Regular(50, -1*math.pi, math.pi, name="dsaMuon_phi"),
-                   lambda objs: objs["dsaMuons"].p4.phi),
+                   lambda objs, mask: objs["dsaMuons"].p4.phi),
         ],
     ),
     # lj
     "lj_n": h.Histogram(
         [
             h.Axis(hist.axis.Integer(0, 10, name="lj_n"),
-                   lambda objs: ak.num(objs["ljs"])),
+                   lambda objs, mask: ak.num(objs["ljs"])),
         ],
     ),
     "lj_pt": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 100, name="lj_pt", label="Lepton jet pT [GeV]"),
-                   lambda objs: objs["ljs"].p4.pt),
+                   lambda objs, mask: objs["ljs"].p4.pt),
         ],
     ),
     "lj_pfIsolation05": h.Histogram(
@@ -209,15 +209,17 @@ hist_defs = {
         [
             h.Axis(hist.axis.Regular(100, 0, 100, name="lj0_pt",
                                      label="Leading lepton jet pT [GeV]"),
-                   lambda objs: objs["ljs"][ak.num(objs["ljs"]) > 0, 0].p4.pt),
+                   lambda objs, mask: objs["ljs"][mask, 0].p4.pt),
         ],
+        evt_mask=lambda objs: ak.num(objs["ljs"]) > 0,
     ),
     "lj1_pt": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 100, name="lj1_pt",
                                      label="Subleading lepton jet pT [GeV]"),
-                   lambda objs: objs["ljs"][ak.num(objs["ljs"]) > 1, 1].p4.pt),
+                   lambda objs, mask: objs["ljs"][mask, 1].p4.pt),
         ],
+        evt_mask=lambda objs: ak.num(objs["ljs"]) > 1,
     ),
     "lj0_e": h.Histogram(
         [
@@ -236,81 +238,81 @@ hist_defs = {
     "lj_eta_phi": h.Histogram(
         [
             h.Axis(hist.axis.Regular(50, -3, 3, name="lj_eta"),
-                   lambda objs: objs["ljs"].p4.eta),
+                   lambda objs, mask: objs["ljs"].p4.eta),
             h.Axis(hist.axis.Regular(50, -1*math.pi, math.pi, name="lj_phi"),
-                   lambda objs: objs["ljs"].p4.phi),
+                   lambda objs, mask: objs["ljs"].p4.phi),
         ],
     ),
     "egm_lj_pt": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 100, name="egm_lj_pt",
                                      label="EGM-type lepton jet pT [GeV]"),
-                   lambda objs: derived_objs["egm_ljs"](objs).p4.pt),
+                   lambda objs, mask: derived_objs["egm_ljs"](objs).p4.pt),
         ],
     ),
     "mu_lj_pt": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 100, name="mu_lj_pt",
                                      label="Mu-type lepton jet pT [GeV]"),
-                   lambda objs: derived_objs["mu_ljs"](objs).p4.pt),
+                   lambda objs, mask: derived_objs["mu_ljs"](objs).p4.pt),
         ],
     ),
     "lj_electronN": h.Histogram(
         [
             h.Axis(hist.axis.Integer(0, 10, name="lj_electronN"),
-                   lambda objs: objs["ljs"].electron_n),
+                   lambda objs, mask: objs["ljs"].electron_n),
         ],
     ),
     "lj_photonN": h.Histogram(
         [
             h.Axis(hist.axis.Integer(0, 10, name="lj_photonN"),
-                   lambda objs: objs["ljs"].photon_n),
+                   lambda objs, mask: objs["ljs"].photon_n),
         ],
     ),
     "lj_electronPhotonN": h.Histogram(
         [
             h.Axis(hist.axis.Integer(0, 10, name="lj_electronPhotonN"),
-                   lambda objs: objs["ljs"].electron_n + objs["ljs"].photon_n),
+                   lambda objs, mask: objs["ljs"].electron_n + objs["ljs"].photon_n),
         ],
     ),
     "lj_muonN": h.Histogram(
         [
             h.Axis(hist.axis.Integer(0, 10, name="lj_muonN"),
-                   lambda objs: objs["ljs"].muon_n),
+                   lambda objs, mask: objs["ljs"].muon_n),
         ],
     ),
     # ljsource
     "ljsource_n": h.Histogram(
         [
             h.Axis(hist.axis.Integer(0, 10, name="ljsource_n"),
-                   lambda objs: ak.num(objs["ljsources"])),
+                   lambda objs, mask: ak.num(objs["ljsources"])),
         ],
     ),
     "ljsource_pt": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 100, name="ljsource_pt",
                                      label="Lepton jet source pT [GeV]"),
-                   lambda objs: objs["ljsources"].p4.pt),
+                   lambda objs, mask: objs["ljsources"].p4.pt),
         ],
     ),
     "ljsource_eta_phi": h.Histogram(
         [
             h.Axis(hist.axis.Regular(50, -3, 3, name="ljsource_eta"),
-                   lambda objs: objs["ljsources"].p4.eta),
+                   lambda objs, mask: objs["ljsources"].p4.eta),
             h.Axis(hist.axis.Regular(50, -1*math.pi, math.pi, name="ljsource_phi"),
-                   lambda objs: objs["ljsources"].p4.phi),
+                   lambda objs, mask: objs["ljsources"].p4.phi),
         ],
     ),
     "ljsource_charge": h.Histogram(
         [
             h.Axis(hist.axis.Integer(-1, 1, name="ljsource_charge"),
-                   lambda objs: objs["ljsources"].charge),
+                   lambda objs, mask: objs["ljsources"].charge),
         ],
     ),
     "ljsource_type": h.Histogram(
         [
             h.Axis(hist.axis.IntCategory([2, 3, 4, 8], name="lj_type"),
-                   lambda objs: objs["ljsources"]["type"]), # avoid ak.Array.type
+                   lambda objs, mask: objs["ljsources"]["type"]), # avoid ak.Array.type
         ],
     ),
     # pfelectron-lj
@@ -318,14 +320,14 @@ hist_defs = {
         [
             # dR(e, nearest LJ)
             h.Axis(hist.axis.Regular(50, 0, 2*math.pi, name="electron_lj_dR"),
-                   lambda objs: dR(objs["electrons"].p4, objs["ljs"].p4))
+                   lambda objs, mask: dR(objs["electrons"].p4, objs["ljs"].p4))
         ],
     ),
     "electron_lj_dR_lowRange": h.Histogram(
         [
             # dR(e, nearest LJ)
             h.Axis(hist.axis.Regular(50, 0, 1.0, name="electron_lj_dR_lowRange"),
-                   lambda objs: dR(objs["electrons"].p4, objs["ljs"].p4))
+                   lambda objs, mask: dR(objs["electrons"].p4, objs["ljs"].p4))
         ],
     ),
     # pfphoton-lj
@@ -333,21 +335,21 @@ hist_defs = {
         [
             # dR(e, nearest LJ)
             h.Axis(hist.axis.Regular(50, 0, 2*math.pi, name="photon_lj_dR"),
-                   lambda objs: dR(objs["photons"].p4, objs["ljs"].p4))
+                   lambda objs, mask: dR(objs["photons"].p4, objs["ljs"].p4))
         ],
     ),
     "photon_lj_dR_lowRange": h.Histogram(
         [
             # dR(e, nearest LJ)
             h.Axis(hist.axis.Regular(50, 0, 1.0, name="photon_lj_dR_lowRange"),
-                   lambda objs: dR(objs["photons"].p4, objs["ljs"].p4))
+                   lambda objs, mask: dR(objs["photons"].p4, objs["ljs"].p4))
         ],
     ),
     "photon_lj_dR_reallyLowRange": h.Histogram(
         [
             # dR(e, nearest LJ)
             h.Axis(hist.axis.Regular(50, 0, 0.1, name="photon_lj_dR_reallyLowRange"),
-                   lambda objs: dR(objs["photons"].p4, objs["ljs"].p4))
+                   lambda objs, mask: dR(objs["photons"].p4, objs["ljs"].p4))
         ],
     ),
     # pfmuon-lj
@@ -355,14 +357,14 @@ hist_defs = {
         [
             # dR(e, nearest LJ)
             h.Axis(hist.axis.Regular(50, 0, 2*math.pi, name="muon_lj_dR"),
-                   lambda objs: dR(objs["muons"].p4, objs["ljs"].p4))
+                   lambda objs, mask: dR(objs["muons"].p4, objs["ljs"].p4))
         ],
     ),
     "muon_lj_dR_lowRange": h.Histogram(
         [
             # dR(e, nearest LJ)
             h.Axis(hist.axis.Regular(50, 0, 1.0, name="muon_lj_dR_lowRange"),
-                   lambda objs: dR(objs["muons"].p4, objs["ljs"].p4))
+                   lambda objs, mask: dR(objs["muons"].p4, objs["ljs"].p4))
         ],
     ),
     # dsamuon-lj
@@ -370,35 +372,38 @@ hist_defs = {
         [
             # dR(e, nearest LJ)
             h.Axis(hist.axis.Regular(50, 0, 2*math.pi, name="dsaMuon_lj_dR"),
-                   lambda objs: dR(objs["dsaMuons"].p4, objs["ljs"].p4))
+                   lambda objs, mask: dR(objs["dsaMuons"].p4, objs["ljs"].p4))
         ],
     ),
     "dsaMuon_lj_dR_lowRange": h.Histogram(
         [
             # dR(e, nearest LJ)
             h.Axis(hist.axis.Regular(50, 0, 1.0, name="dsaMuon_lj_dR_lowRange"),
-                   lambda objs: dR(objs["dsaMuons"].p4, objs["ljs"].p4))
+                   lambda objs, mask: dR(objs["dsaMuons"].p4, objs["ljs"].p4))
         ],
     ),
     # lj-lj
     "lj_lj_absdphi": h.Histogram(
         [
             h.Axis(hist.axis.Regular(50, 0, 2*math.pi, name="ljlj_absdphi"),
-                   lambda objs: abs(objs["ljs"][ak.num(objs["ljs"]) > 1, 1].p4.phi
-                                    - objs["ljs"][ak.num(objs["ljs"]) > 1, 0].p4.phi)),
+                   lambda objs, mask: abs(objs["ljs"][mask, 1].p4.phi
+                                          - objs["ljs"][mask, 0].p4.phi)),
         ],
+        evt_mask=lambda objs: ak.num(objs["ljs"]) > 1,
     ),
     "lj_lj_invmass": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 2000, name="ljlj_mass"),
-                   lambda objs: objs["ljs"][ak.num(objs["ljs"]) > 1, :2].p4.sum().mass),
+                   lambda objs, mask: objs["ljs"][mask, :2].p4.sum().mass),
         ],
+        evt_mask=lambda objs: ak.num(objs["ljs"]) > 1,
     ),
     "lj_lj_invmass_lowRange": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 500, name="ljlj_mass"),
-                   lambda objs: objs["ljs"][ak.num(objs["ljs"]) > 1, :2].p4.sum().mass),
+                   lambda objs, mask: objs["ljs"][mask, :2].p4.sum().mass),
         ],
+        evt_mask=lambda objs: ak.num(objs["ljs"]) > 1,
     ),
     # ABCD plane
     "abcd_lj_lj_dphi_vs_lj0_pfIsolationPt05": h.Histogram(
@@ -416,151 +421,163 @@ hist_defs = {
     "gen_abspid": h.Histogram(
         [
             h.Axis(hist.axis.Integer(0, 40, name="gen_abspid"),
-                   lambda objs: abs(objs["gens"].pid)),
+                   lambda objs, mask: abs(objs["gens"].pid)),
         ],
     ),
     # genelectron
     "genE_pt": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 200, name="genE_pt"),
-                   lambda objs: abs(objs["genEs"].p4.pt)),
+                   lambda objs, mask: abs(objs["genEs"].p4.pt)),
         ],
     ),
     "genE0_pt": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 200, name="genE0_pt_lowRange"),
-                   lambda objs: objs["genEs"][ak.num(objs["genEs"]) > 0, 0].p4.pt),
-        ]
+                   lambda objs, mask: objs["genEs"][mask, 0].p4.pt),
+        ],
+        evt_mask=lambda objs: ak.num(objs["genEs"]) > 0,
     ),
     "genE1_pt": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 200, name="genE1_pt_lowRange"),
-                   lambda objs: objs["genEs"][ak.num(objs["genEs"]) > 1, 1].p4.pt),
-        ]
+                   lambda objs, mask: objs["genEs"][mask, 1].p4.pt),
+        ],
+        evt_mask=lambda objs: ak.num(objs["genEs"]) > 1,
     ),
     "genE0_pt_highRange": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 1000, name="genE0_pt"),
-                   lambda objs: objs["genEs"][ak.num(objs["genEs"]) > 0, 0].p4.pt),
-        ]
+                   lambda objs, mask: objs["genEs"][mask, 0].p4.pt),
+        ],
+        evt_mask=lambda objs: ak.num(objs["genEs"]) > 0,
     ),
     "genE1_pt_highRange": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 1000, name="genE1_pt"),
-                   lambda objs: objs["genEs"][ak.num(objs["genEs"]) > 1, 1].p4.pt),
-        ]
+                   lambda objs, mask: objs["genEs"][mask, 1].p4.pt),
+        ],
+        evt_mask=lambda objs: ak.num(objs["genEs"]) > 1,
     ),
     # genelectron-genelectron
     "genE_genE_dR": h.Histogram(
         [
             # dR(subleading gen E, leading gen E)
             h.Axis(hist.axis.Regular(50, 0, 1.0, name="genE_genE_dR"),
-                   lambda objs: objs["genEs"][ak.num(objs["genEs"]) > 1, 1].p4.delta_r(
-                       objs["genEs"][ak.num(objs["genEs"]) > 1, 0].p4)),
+                   lambda objs, mask: objs[mask, 1].p4.delta_r(objs["genEs"][mask, 0].p4)),
         ],
+        evt_mask=lambda objs: ak.num(objs["genEs"]) > 1,
     ),
     "genE_genE_pt": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 200, name="genE_genE_pt"),
-                   lambda objs: objs["genEs"][ak.num(objs["genEs"]) > 1, :2].p4.sum().pt),
+                   lambda objs, mask: objs["genEs"][mask, :2].p4.sum().pt),
         ],
+        evt_mask=lambda objs: ak.num(objs["genEs"]) > 1,
     ),
     # genmuon
     "genMu_pt": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 200, name="genMu_pt"),
-                   lambda objs: abs(objs["genMus"].p4.pt)),
+                   lambda objs, mask: abs(objs["genMus"].p4.pt)),
         ],
     ),
     "genMu0_pt": h.Histogram(
         [
             h.Axis(hist.axis.Regular(50, 0, 100, name="genMu0_pt"),
-                   lambda objs:objs["genMus"][ak.num(objs["genMus"]) > 0, 0].p4.pt),
-        ]
+                   lambda objs, mask: objs["genMus"][mask, 0].p4.pt),
+        ],
+        evt_mask=lambda objs: ak.num(objs["genMus"]) > 0
     ),
     "genMu1_pt": h.Histogram(
         [
             h.Axis(hist.axis.Regular(50, 0, 100, name="genMu1_pt"),
-                   lambda objs: objs["genMus"][ak.num(objs["genMus"]) > 1, 1].p4.pt),
-        ]
+                   lambda objs, mask: objs["genMus"][mask, 1].p4.pt),
+        ],
+        evt_mask=lambda objs: ak.num(objs["genMus"]) > 1,
     ),
     "genMu0_pt_highRange": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 1000, name="genMu0_pt"),
-                   lambda objs:objs["genMus"][ak.num(objs["genMus"]) > 0, 0].p4.pt),
-        ]
+                   lambda objs, mask: objs["genMus"][mask, 0].p4.pt),
+        ],
+        evt_mask=lambda objs: ak.num(objs["genMus"]) > 0, 
     ),
     "genMu1_pt_highRange": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 1000, name="genMu1_pt"),
-                   lambda objs: objs["genMus"][ak.num(objs["genMus"]) > 1, 1].p4.pt),
-        ]
+                   lambda objs, mask: objs["genMus"][mask, 1].p4.pt),
+        ],
+        evt_mask=lambda objs: ak.num(objs["genMus"]) > 1, 
     ),
     # genmuon-genmuon
     "genMu_genMu_dR": h.Histogram(
         [
             # dR(subleading gen Mu, leading gen Mu)
             h.Axis(hist.axis.Regular(50, 0, 1.0, name="genMu_genMu_dR"),
-                   lambda objs: objs["genMus"][ak.num(objs["genMus"]) > 1, 1].p4.delta_r(
-                       objs["genMus"][ak.num(objs["genMus"]) > 1, 0].p4)),
+                   lambda objs, mask: objs["genMus"][mask, 1].p4.delta_r(
+                       objs["genMus"][mask, 0].p4)),
         ],
+        evt_mask=lambda objs: ak.num(objs["genMus"]) > 1,
     ),
     "genMu_genMu_pt": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 200, name="genMu_genMu_pt"),
-                   lambda objs: objs["genMus"][ak.num(objs["genMus"]) > 1, :2].p4.sum().pt),
+                   lambda objs, mask: objs["genMus"][mask, :2].p4.sum().pt),
         ],
+        evt_mask=lambda objs: ak.num(objs["genMus"]) > 1,
     ),
     # gen dark photons (A)
     "genA_pt": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 200, name="genA_pt"),
-                   lambda objs: abs(objs["genAs"].p4.pt)),
+                   lambda objs, mask: abs(objs["genAs"].p4.pt)),
         ],
     ),
     #gen dark photons(A) high range
     "genA_pt_highRange": h.Histogram(
         [
             h.Axis(hist.axis.Regular(140, 0, 700, name="genA_pt"),
-                   lambda objs: abs(objs["genAs"].p4.pt)),
+                   lambda objs, mask: abs(objs["genAs"].p4.pt)),
         ],
     ),
     "genA_eta_phi": h.Histogram(
         [
             h.Axis(hist.axis.Regular(50, -3, 3, name="genA_eta"),
-                   lambda objs: objs["genAs"].p4.eta),
+                   lambda objs, mask: objs["genAs"].p4.eta),
             h.Axis(hist.axis.Regular(50, -1*math.pi, math.pi, name="genA_phi"),
-                   lambda objs: objs["genAs"].p4.phi),
+                   lambda objs, mask: objs["genAs"].p4.phi),
         ],
     ),
     # genA-genA
     "genA_genA_dphi": h.Histogram(
         [
             h.Axis(hist.axis.Regular(50, 0, 2*math.pi, name="genA_genA_dphi"),
-                   lambda objs: abs(objs["genAs"][ak.num(objs["genAs"]) > 1, 1].p4.phi
-                                    - objs["genAs"][ak.num(objs["genAs"]) > 1, 0].p4.phi)),
+                   lambda objs, mask: abs(objs["genAs"][mask, 1].p4.phi
+                                          - objs["genAs"][mask, 0].p4.phi)),
         ],
+        evt_mask=lambda objs: ak.num(objs["genAs"]) > 1,
     ),
     # genA-LJ
     "genA_lj_dR": h.Histogram(
         [
             # dR(A, nearest LJ)
             h.Axis(hist.axis.Regular(50, 0, 2*math.pi, name="genA_lj_dR"),
-                   lambda objs: dR(objs["genAs"].p4, objs["ljs"].p4))
+                   lambda objs, mask: dR(objs["genAs"].p4, objs["ljs"].p4))
         ],
     ),
     "genA_lj_dR_lowRange": h.Histogram(
         [
             # dR(A, nearest LJ)
             h.Axis(hist.axis.Regular(50, 0, 1.0, name="genA_lj_dR_lowRange"),
-                   lambda objs: dR(objs["genAs"].p4, objs["ljs"].p4))
+                   lambda objs, mask: dR(objs["genAs"].p4, objs["ljs"].p4))
         ],
     ),
     "lj_genA_ptRatio": h.Histogram(
         [
             # (LJ pT)/(nearest A pT)
             h.Axis(hist.axis.Regular(50, 0, 2.0, name="lj_genA_ptRatio"),
-                   lambda objs: objs["ljs"].p4.pt
+                   lambda objs, mask: objs["ljs"].p4.pt
                        / objs["ljs"].p4.nearest(objs["genAs"].p4).pt),
         ],
     ),
@@ -568,7 +585,7 @@ hist_defs = {
         [
             # (LJ pT)/(nearest A pT)
             h.Axis(hist.axis.Regular(50, 0, 2.0, name="egm_lj_genA_ptRatio"),
-                   lambda objs: derived_objs["egm_ljs"](objs).p4.pt
+                   lambda objs, mask: derived_objs["egm_ljs"](objs).p4.pt
                        / derived_objs["egm_ljs"](objs).p4.nearest(objs["genAs"].p4).pt),
         ],
     ),
@@ -576,7 +593,7 @@ hist_defs = {
         [
             # (LJ pT)/(nearest A pT)
             h.Axis(hist.axis.Regular(50, 0, 2.0, name="mu_lj_genA_ptRatio"),
-                   lambda objs: derived_objs["mu_ljs"](objs).p4.pt
+                   lambda objs, mask: derived_objs["mu_ljs"](objs).p4.pt
                        / derived_objs["mu_ljs"](objs).p4.nearest(objs["genAs"].p4).pt),
         ],
     ),

--- a/sidm/definitions/hists.py
+++ b/sidm/definitions/hists.py
@@ -503,14 +503,14 @@ hist_defs = {
             h.Axis(hist.axis.Regular(100, 0, 1000, name="genMu0_pt"),
                    lambda objs, mask: objs["genMus"][mask, 0].p4.pt),
         ],
-        evt_mask=lambda objs: ak.num(objs["genMus"]) > 0, 
+        evt_mask=lambda objs: ak.num(objs["genMus"]) > 0,
     ),
     "genMu1_pt_highRange": h.Histogram(
         [
             h.Axis(hist.axis.Regular(100, 0, 1000, name="genMu1_pt"),
                    lambda objs, mask: objs["genMus"][mask, 1].p4.pt),
         ],
-        evt_mask=lambda objs: ak.num(objs["genMus"]) > 1, 
+        evt_mask=lambda objs: ak.num(objs["genMus"]) > 1,
     ),
     # genmuon-genmuon
     "genMu_genMu_dR": h.Histogram(

--- a/sidm/definitions/objects.py
+++ b/sidm/definitions/objects.py
@@ -18,7 +18,7 @@ primary_objs = {
     "genAs": lambda evts: evts.gen[abs(evts.gen.pid) == 32],
 }
 
-# define objects whose definitions on analysis choices
+# define objects whose definitions depend on analysis choices
 derived_objs = {
     "mu_ljs": lambda objs: objs["ljs"][(objs["ljs"].muon_n >= 2)],
     "egm_ljs": lambda objs: objs["ljs"][(objs["ljs"].muon_n == 0)],

--- a/sidm/studies/mission_abcd.ipynb
+++ b/sidm/studies/mission_abcd.ipynb
@@ -102,7 +102,6 @@
    "cell_type": "markdown",
    "id": "2a7eda6e-fe24-440c-be8f-cf4ec9cc02ed",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -153,29 +152,29 @@
        " 'tomatchfilter_HLTDoubleL2Mu23NoVtx2ChaCosmicSeedNoL2Matched',\n",
        " 'tomatchfilter_HLTDoubleL2Mu25NoVtx2ChaEta2p4',\n",
        " 'tomatchfilter_HLTDoubleL2Mu25NoVtx2ChaCosmicSeedEta2p4',\n",
-       " 'pfMetT0pcT1',\n",
        " 'genmet',\n",
-       " 'pfMetT0pcT1Txy',\n",
        " 'pfMetT1',\n",
+       " 'pfMetT0pcT1Txy',\n",
+       " 'pfMetT0pcT1',\n",
        " 'pfMet',\n",
-       " 'muon',\n",
-       " 'gen',\n",
+       " 'proxymuon',\n",
        " 'pv',\n",
        " 'hftagscore',\n",
-       " 'cosmiconeleg',\n",
        " 'electron',\n",
-       " 'ljsource',\n",
-       " 'metfilters',\n",
-       " 'photon',\n",
-       " 'proxymuon',\n",
        " 'dsamuon',\n",
-       " 'genjet',\n",
-       " 'trigobj',\n",
-       " 'cosmicmuon',\n",
-       " 'pfphoton',\n",
-       " 'pfjet',\n",
        " 'cosmicveto',\n",
-       " 'akjet_ak4PFJetsCHS']"
+       " 'muon',\n",
+       " 'trigobj',\n",
+       " 'pfphoton',\n",
+       " 'cosmicmuon',\n",
+       " 'cosmiconeleg',\n",
+       " 'akjet_ak4PFJetsCHS',\n",
+       " 'gen',\n",
+       " 'photon',\n",
+       " 'ljsource',\n",
+       " 'pfjet',\n",
+       " 'metfilters',\n",
+       " 'genjet']"
       ]
      },
      "execution_count": 2,
@@ -310,7 +309,6 @@
    "cell_type": "markdown",
    "id": "432b783a-c622-44a0-9c6e-f1f56cfae3ad",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -328,7 +326,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7ae40c78f262434a9169b7acadedc805",
+       "model_id": "e4aaa72ebd4743fa83c041af57547bae",
        "version_major": 2,
        "version_minor": 0
       },
@@ -365,7 +363,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4823679f80cb436982949076dbc433c7",
+       "model_id": "c93f9386e6e1406bad1c9c41c5e5c2dc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -621,12 +619,12 @@
        " 'mindr',\n",
        " 'cleaned',\n",
        " 'averagevtx',\n",
-       " 'p4',\n",
        " 'medianvtx',\n",
-       " 'kinvtx',\n",
+       " 'p4',\n",
        " 'pfcands',\n",
+       " 'klmvtx',\n",
        " 'pfcand',\n",
-       " 'klmvtx']"
+       " 'kinvtx']"
       ]
      },
      "execution_count": 10,
@@ -946,7 +944,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7fa2029f1f70>"
+       "<matplotlib.legend.Legend at 0x7f2414029ac0>"
       ]
      },
      "execution_count": 22,
@@ -979,7 +977,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7fa200e52c70>"
+       "<matplotlib.legend.Legend at 0x7f23fef1f940>"
       ]
      },
      "execution_count": 23,
@@ -1188,7 +1186,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "800a266820a44cb885d8b4b0794af12c",
+       "model_id": "33c54928c8aa428abe8e4f6d1070a3d5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1225,7 +1223,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a683ae7dc1684dd8a0e32a65b9c569d8",
+       "model_id": "0fc47a694411494890e74c0e259a84c7",
        "version_major": 2,
        "version_minor": 0
       },

--- a/sidm/test_notebooks/test_SidmProcessor.ipynb
+++ b/sidm/test_notebooks/test_SidmProcessor.ipynb
@@ -75,8 +75,8 @@
     {
      "data": {
       "text/plain": [
-       "{'SIDM_XXTo2ATo2Mu2E_mXX-100_mA-1p2_ctau-9p6': {'cutflow': {'4mu': <sidm.tools.cutflow.Cutflow at 0x7f26cc949a00>,\n",
-       "   '2mu2e': <sidm.tools.cutflow.Cutflow at 0x7f26cc9816a0>},\n",
+       "{'SIDM_XXTo2ATo2Mu2E_mXX-100_mA-1p2_ctau-9p6': {'cutflow': {'4mu': <sidm.tools.cutflow.Cutflow at 0x7f8715f36be0>,\n",
+       "   '2mu2e': <sidm.tools.cutflow.Cutflow at 0x7f8715f55700>},\n",
        "  'hists': {'pv_n': Hist(\n",
        "     StrCategory(['4mu', '2mu2e'], name='channel'),\n",
        "     Regular(50, 0, 100, name='pv_n'),\n",
@@ -169,6 +169,14 @@
        "     StrCategory(['4mu', '2mu2e'], name='channel'),\n",
        "     Regular(100, 0, 100, name='lj1_pt', label='Subleading lepton jet pT [GeV]'),\n",
        "     storage=Weight()) # Sum: WeightedSum(value=1914, variance=3022.89),\n",
+       "   'lj0_e': Hist(\n",
+       "     StrCategory(['4mu', '2mu2e'], name='channel'),\n",
+       "     Regular(350, 0, 700, name='lj_e', label='Leading lepton jet E [GeV]'),\n",
+       "     storage=Weight()) # Sum: WeightedSum(value=1913.39, variance=3022.53) (WeightedSum(value=1914, variance=3022.89) with flow),\n",
+       "   'lj1_e': Hist(\n",
+       "     StrCategory(['4mu', '2mu2e'], name='channel'),\n",
+       "     Regular(350, 0, 700, name='lj_e', label='Subleading lepton jet E [GeV]'),\n",
+       "     storage=Weight()) # Sum: WeightedSum(value=1914, variance=3022.89),\n",
        "   'lj_eta_phi': Hist(\n",
        "     StrCategory(['4mu', '2mu2e'], name='channel'),\n",
        "     Regular(50, -3, 3, name='lj_eta'),\n",
@@ -258,6 +266,47 @@
        "   'lj_lj_invmass_lowRange': Hist(\n",
        "     StrCategory(['4mu', '2mu2e'], name='channel'),\n",
        "     Regular(100, 0, 500, name='ljlj_mass'),\n",
+       "     storage=Weight()) # Sum: WeightedSum(value=1914, variance=3022.89),\n",
+       "   'lj_pfIsolation05': Hist(\n",
+       "     StrCategory(['4mu', '2mu2e'], name='channel'),\n",
+       "     Regular(80, 0, 0.8, name='lj_pfIsolation05', label='Lepton jet isolation'),\n",
+       "     storage=Weight()) # Sum: WeightedSum(value=3828.71, variance=6046.29),\n",
+       "   'lj0_pfIsolation05': Hist(\n",
+       "     StrCategory(['4mu', '2mu2e'], name='channel'),\n",
+       "     Regular(80, 0, 0.8, name='lj_pfIsolation05', label='Leading lepton jet isolation'),\n",
+       "     storage=Weight()) # Sum: WeightedSum(value=1914, variance=3022.89),\n",
+       "   'lj1_pfIsolation05': Hist(\n",
+       "     StrCategory(['4mu', '2mu2e'], name='channel'),\n",
+       "     Regular(80, 0, 0.8, name='lj_pfIsolation05', label='Subleading lepton jet isolation'),\n",
+       "     storage=Weight()) # Sum: WeightedSum(value=1914, variance=3022.89),\n",
+       "   'lj_pfIsolationPtNoPU05': Hist(\n",
+       "     StrCategory(['4mu', '2mu2e'], name='channel'),\n",
+       "     Regular(80, 0, 0.8, name='lj_pfIsolationPtNoPU05', label='Lepton jet isolation'),\n",
+       "     storage=Weight()) # Sum: WeightedSum(value=3828.71, variance=6046.29),\n",
+       "   'lj_pfIsolationPt05': Hist(\n",
+       "     StrCategory(['4mu', '2mu2e'], name='channel'),\n",
+       "     Regular(80, 0, 0.8, name='lj_pfIsolationPt05', label='Lepton jet isolation'),\n",
+       "     storage=Weight()) # Sum: WeightedSum(value=3828.71, variance=6046.29),\n",
+       "   'lj_pfIsolation07': Hist(\n",
+       "     StrCategory(['4mu', '2mu2e'], name='channel'),\n",
+       "     Regular(80, 0, 0.8, name='lj_pfIsolation07', label='Lepton jet isolation'),\n",
+       "     storage=Weight()) # Sum: WeightedSum(value=3828.71, variance=6046.29),\n",
+       "   'lj_pfIsolationPtNoPU07': Hist(\n",
+       "     StrCategory(['4mu', '2mu2e'], name='channel'),\n",
+       "     Regular(80, 0, 0.8, name='lj_pfIsolationPtNoPU07', label='Lepton jet isolation'),\n",
+       "     storage=Weight()) # Sum: WeightedSum(value=3828.71, variance=6046.29),\n",
+       "   'lj_pfIsolationPt07': Hist(\n",
+       "     StrCategory(['4mu', '2mu2e'], name='channel'),\n",
+       "     Regular(80, 0, 0.8, name='lj_pfIsolationPt07', label='Lepton jet isolation'),\n",
+       "     storage=Weight()) # Sum: WeightedSum(value=3828.71, variance=6046.29),\n",
+       "   'lj_pfiso': Hist(\n",
+       "     StrCategory(['4mu', '2mu2e'], name='channel'),\n",
+       "     Regular(80, 0, 0.8, name='lj_pfiso', label='Lepton jet isolation'),\n",
+       "     storage=Weight()) # Sum: WeightedSum(value=3765.72, variance=5930.71) (WeightedSum(value=3828.71, variance=6046.29) with flow),\n",
+       "   'abcd_lj_lj_dphi_vs_lj0_pfIsolationPt05': Hist(\n",
+       "     StrCategory(['4mu', '2mu2e'], name='channel'),\n",
+       "     Regular(200, 0, 6.28319, name='ljlj_absdphi', label='Lepton jet pair |$\\\\Delta\\\\phi$|'),\n",
+       "     Regular(80, 0, 0.8, name='lj_pfIsolationPt05', label='Leading lepton jet isolation'),\n",
        "     storage=Weight()) # Sum: WeightedSum(value=1914, variance=3022.89)}}}"
       ]
      },
@@ -467,7 +516,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7f26b6e50040>"
+       "<matplotlib.legend.Legend at 0x7f8714426be0>"
       ]
      },
      "execution_count": 12,
@@ -528,7 +577,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7f26b6cccd00>"
+       "<matplotlib.legend.Legend at 0x7f871429ea90>"
       ]
      },
      "execution_count": 14,
@@ -561,7 +610,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7f26b6af8e50>"
+       "<matplotlib.legend.Legend at 0x7f87140efc10>"
       ]
      },
      "execution_count": 15,
@@ -593,7 +642,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7f26b6925ee0>"
+       "<matplotlib.legend.Legend at 0x7f87144628b0>"
       ]
      },
      "execution_count": 16,
@@ -625,7 +674,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7f26b680dac0>"
+       "<matplotlib.legend.Legend at 0x7f86ffdecdf0>"
       ]
      },
      "execution_count": 17,

--- a/sidm/test_notebooks/test_SidmProcessor.ipynb
+++ b/sidm/test_notebooks/test_SidmProcessor.ipynb
@@ -75,8 +75,8 @@
     {
      "data": {
       "text/plain": [
-       "{'SIDM_XXTo2ATo2Mu2E_mXX-100_mA-1p2_ctau-9p6': {'cutflow': {'4mu': <sidm.tools.cutflow.Cutflow at 0x7fc8ce3942b0>,\n",
-       "   '2mu2e': <sidm.tools.cutflow.Cutflow at 0x7fc8ce399b50>},\n",
+       "{'SIDM_XXTo2ATo2Mu2E_mXX-100_mA-1p2_ctau-9p6': {'cutflow': {'4mu': <sidm.tools.cutflow.Cutflow at 0x7f26cc949a00>,\n",
+       "   '2mu2e': <sidm.tools.cutflow.Cutflow at 0x7f26cc9816a0>},\n",
        "  'hists': {'pv_n': Hist(\n",
        "     StrCategory(['4mu', '2mu2e'], name='channel'),\n",
        "     Regular(50, 0, 100, name='pv_n'),\n",
@@ -467,7 +467,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7fc8cc8c3d60>"
+       "<matplotlib.legend.Legend at 0x7f26b6e50040>"
       ]
      },
      "execution_count": 12,
@@ -528,7 +528,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7fc8cc749340>"
+       "<matplotlib.legend.Legend at 0x7f26b6cccd00>"
       ]
      },
      "execution_count": 14,
@@ -561,7 +561,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7fc8cc56bd00>"
+       "<matplotlib.legend.Legend at 0x7f26b6af8e50>"
       ]
      },
      "execution_count": 15,
@@ -593,7 +593,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7fc8cc419a30>"
+       "<matplotlib.legend.Legend at 0x7f26b6925ee0>"
       ]
      },
      "execution_count": 16,
@@ -625,7 +625,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x7fc8cc2889a0>"
+       "<matplotlib.legend.Legend at 0x7f26b680dac0>"
       ]
      },
      "execution_count": 17,
@@ -700,14 +700,6 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "21131f58-d6d7-42f6-80d8-77dae8727e5a",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "afd2b777-3074-46d9-8787-e5d68c0e9265",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/sidm/tools/histogram.py
+++ b/sidm/tools/histogram.py
@@ -9,12 +9,16 @@ class Histogram:
     """Class to represent histograms
 
     Histogram mostly exists so that hist.Hists and the appropriate filling arguments can be
-    defined in one place.
+    defined in one place. In addition to the filling function associated with each Axis, the user
+    can optionally provide an event mask that is applied to all object collections used to fill
+    the histogram, e.g. to ensure only events with >=2 muons are used to fill dR(mu, mu) hists.
     """
 
-    def __init__(self, axes, storage="weight"):
+    def __init__(self, axes, storage="weight", evt_mask=None):
         self.axes = axes
         self.storage = storage
+        # Allow all events to pass if no mask is explicitly provided
+        self.evt_mask = (lambda objs: slice(None)) if evt_mask is None else evt_mask
         self.hist = None
 
     def make_hist(self, channels=None):
@@ -26,16 +30,17 @@ class Histogram:
         # optionally add channels axis to hist
         if channels is not None:
             channel_axis = hist.axis.StrCategory(channels, name="channel")
-            self.axes = [Axis(channel_axis, lambda objs: objs["ch"])] + self.axes
+            self.axes = [Axis(channel_axis, lambda objs, mask: objs["ch"])] + self.axes
 
         axes = [a.axis for a in self.axes]
         self.hist = hist.Hist(*axes, storage=self.storage)
 
     def fill(self, objs, evt_weights):
         """Fill associated hist.Hist"""
-        fill_args = {a.name: a.fill_func(objs) for a in self.axes}
+        fill_args = {a.name: a.fill_func(objs, self.evt_mask(objs)) for a in self.axes}
         # Use last axis to define weight structure to avoid channels axis
-        fill_args["weight"] = evt_weights*ak.ones_like(fill_args[self.axes[-1].name])
+        masked_weights = evt_weights[self.evt_mask(objs)]
+        fill_args["weight"] = masked_weights*ak.ones_like(fill_args[self.axes[-1].name])
         for name in fill_args.keys():
             if name != "channel":
                 fill_args[name] = ak.flatten(fill_args[name], axis=None)


### PR DESCRIPTION
Adds an optional argument for histograms to better handle cases where an additional selection is required before filling the hist, e.g. only considering events with >=2 muons when computing dR(mu, mu) to fill a histogram.