### PR TITLE
Add preliminary ntuple config maker and v4 ntuple locations

### DIFF
--- a/sidm/configs/ntuple_locations.yaml
+++ b/sidm/configs/ntuple_locations.yaml
@@ -4,7 +4,7 @@
 
 #Most recent ntuples from Weinan -- only includes 2mu2e
 ffntuple_v4:
-  path: root://cmseos.fnal.gov//store/group/lpcmetx/SIDM/ffNtupleV4/2018/
+  path: root://xcache//store/group/lpcmetx/SIDM/ffNtupleV4/2018/
   samples:
     2Mu2E_1000GeV_0p25GeV_0p002mm:
       files:

--- a/sidm/configs/ntuple_locations.yaml
+++ b/sidm/configs/ntuple_locations.yaml
@@ -2,7 +2,7 @@
 # Automatically generated using sidm/scripts/add_ntuples.py
 
 
-#Most recent ntuples from Weinan -- only includes 2mu2e
+# Most recent ntuples from Weinan -- only includes 2mu2e
 ffntuple_v4:
   path: root://xcache//store/group/lpcmetx/SIDM/ffNtupleV4/2018/
   samples:
@@ -725,4 +725,3047 @@ ffntuple_v4:
       - ffNtuple_7.root
       - ffNtuple_8.root
       path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-5_ctau-5_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_152214/0000/
+
+
+
+# V2 ntuples from Weinan; signal and bg available, but only include signal for now
+ffntuple_v2:
+  path: root://xcache//store/group/lpcmetx/SIDM/ffNtupleV2/2018/
+  samples:
+    2Mu2E_1000GeV_0p25GeV_0p002mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-0p25_ctau-0p002_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_041854/0000/
+    2Mu2E_1000GeV_0p25GeV_0p02mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-0p25_ctau-0p02_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200323_181235/0000/
+    2Mu2E_1000GeV_0p25GeV_0p2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-0p25_ctau-0p2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_042141/0000/
+    2Mu2E_1000GeV_0p25GeV_1mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_20.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-0p25_ctau-1_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_041949/0000/
+    2Mu2E_1000GeV_0p25GeV_2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-0p25_ctau-2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_042045/0000/
+    2Mu2E_1000GeV_1p2GeV_0p0096mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-1p2_ctau-0p0096_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_042331/0000/
+    2Mu2E_1000GeV_1p2GeV_0p096mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-1p2_ctau-0p096_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_042657/0000/
+    2Mu2E_1000GeV_1p2GeV_0p96mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-1p2_ctau-0p96_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_042603/0000/
+    2Mu2E_1000GeV_1p2GeV_4p8mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-1p2_ctau-4p8_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_042419/0000/
+    2Mu2E_1000GeV_1p2GeV_9p6mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-1p2_ctau-9p6_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_042512/0000/
+    2Mu2E_1000GeV_5GeV_0p04mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-5_ctau-0p04_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_042746/0000/
+    2Mu2E_1000GeV_5GeV_0p4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-5_ctau-0p4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200402_183314/0000/
+    2Mu2E_1000GeV_5GeV_20mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-5_ctau-20_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_042839/0000/
+    2Mu2E_1000GeV_5GeV_40mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-5_ctau-40_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200402_183413/0000/
+    2Mu2E_1000GeV_5GeV_4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-5_ctau-4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043029/0000/
+    2Mu2E_100GeV_0p25GeV_0p02mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-0p25_ctau-0p02_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043216/0000/
+    2Mu2E_100GeV_0p25GeV_0p2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-0p25_ctau-0p2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043544/0000/
+    2Mu2E_100GeV_0p25GeV_10mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-0p25_ctau-10_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200323_181521/0000/
+    2Mu2E_100GeV_0p25GeV_20mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-0p25_ctau-20_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043400/0000/
+    2Mu2E_100GeV_0p25GeV_2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-0p25_ctau-2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043452/0000/
+    2Mu2E_100GeV_1p2GeV_0p096mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-1p2_ctau-0p096_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043634/0000/
+    2Mu2E_100GeV_1p2GeV_0p96mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-1p2_ctau-0p96_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200402_183509/0000/
+    2Mu2E_100GeV_1p2GeV_48mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-1p2_ctau-48_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043728/0000/
+    2Mu2E_100GeV_1p2GeV_96mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-1p2_ctau-96_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043817/0000/
+    2Mu2E_100GeV_1p2GeV_9p6mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-1p2_ctau-9p6_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043910/0000/
+    2Mu2E_100GeV_5GeV_0p4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-5_ctau-0p4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044054/0000/
+    2Mu2E_100GeV_5GeV_200mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-5_ctau-200_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044146/0000/
+    2Mu2E_100GeV_5GeV_400mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-5_ctau-400_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044243/0000/
+    2Mu2E_100GeV_5GeV_40mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_20.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-5_ctau-40_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044339/0000/
+    2Mu2E_100GeV_5GeV_4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-5_ctau-4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044437/0000/
+    2Mu2E_150GeV_0p25GeV_0p013mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-0p25_ctau-0p013_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044527/0000/
+    2Mu2E_150GeV_0p25GeV_0p13mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-0p25_ctau-0p13_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044856/0000/
+    2Mu2E_150GeV_0p25GeV_13mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-0p25_ctau-13_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044709/0000/
+    2Mu2E_150GeV_0p25GeV_1p3mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-0p25_ctau-1p3_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044801/0000/
+    2Mu2E_150GeV_0p25GeV_6p7mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-0p25_ctau-6p7_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044620/0000/
+    2Mu2E_150GeV_1p2GeV_0p064mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-1p2_ctau-0p064_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044953/0000/
+    2Mu2E_150GeV_1p2GeV_0p64mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-1p2_ctau-0p64_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045327/0000/
+    2Mu2E_150GeV_1p2GeV_32mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-1p2_ctau-32_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045044/0000/
+    2Mu2E_150GeV_1p2GeV_64mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-1p2_ctau-64_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045144/0000/
+    2Mu2E_150GeV_1p2GeV_6p4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-1p2_ctau-6p4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045241/0000/
+    2Mu2E_150GeV_5GeV_0p27mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_20.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-5_ctau-0p27_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045423/0000/
+    2Mu2E_150GeV_5GeV_130mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-5_ctau-130_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045510/0000/
+    2Mu2E_150GeV_5GeV_270mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-5_ctau-270_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045610/0000/
+    2Mu2E_150GeV_5GeV_27mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-5_ctau-27_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045705/0000/
+    2Mu2E_150GeV_5GeV_2p7mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-5_ctau-2p7_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045750/0000/
+    2Mu2E_200GeV_0p25GeV_0p01mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-0p25_ctau-0p01_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045845/0000/
+    2Mu2E_200GeV_0p25GeV_0p1mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-0p25_ctau-0p1_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200403_193612/0000/
+    2Mu2E_200GeV_0p25GeV_10mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-0p25_ctau-10_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200402_183755/0000/
+    2Mu2E_200GeV_0p25GeV_1mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-0p25_ctau-1_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200325_193122/0000/
+    2Mu2E_200GeV_0p25GeV_5mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-0p25_ctau-5_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045932/0000/
+    2Mu2E_200GeV_1p2GeV_0p048mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-1p2_ctau-0p048_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_050216/0000/
+    2Mu2E_200GeV_1p2GeV_0p48mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-1p2_ctau-0p48_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200322_035435/0000/
+    2Mu2E_200GeV_1p2GeV_24mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-1p2_ctau-24_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_050304/0000/
+    2Mu2E_200GeV_1p2GeV_48mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-1p2_ctau-48_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_050407/0000/
+    2Mu2E_200GeV_1p2GeV_4p8mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-1p2_ctau-4p8_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_050504/0000/
+    2Mu2E_200GeV_5GeV_0p2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-5_ctau-0p2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_050646/0000/
+    2Mu2E_200GeV_5GeV_100mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-5_ctau-100_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200322_035532/0000/
+    2Mu2E_200GeV_5GeV_200mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-5_ctau-200_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_050833/0000/
+    2Mu2E_200GeV_5GeV_20mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-5_ctau-20_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_050918/0000/
+    2Mu2E_200GeV_5GeV_2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-5_ctau-2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200322_035628/0000/
+    2Mu2E_500GeV_0p25GeV_0p004mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-0p25_ctau-0p004_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200322_035722/0000/
+    2Mu2E_500GeV_0p25GeV_0p04mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-0p25_ctau-0p04_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_051451/0000/
+    2Mu2E_500GeV_0p25GeV_0p4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-0p25_ctau-0p4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_051407/0000/
+    2Mu2E_500GeV_0p25GeV_2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-0p25_ctau-2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200403_193809/0000/
+    2Mu2E_500GeV_0p25GeV_4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-0p25_ctau-4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_051310/0000/
+    2Mu2E_500GeV_1p2GeV_0p019mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-1p2_ctau-0p019_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200317_180511/ffNtuple_0.root/
+    2Mu2E_500GeV_1p2GeV_0p19mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-1p2_ctau-0p19_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200317_180512/ffNtuple_0.root/
+    2Mu2E_500GeV_1p2GeV_19mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-1p2_ctau-19_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200317_180512/ffNtuple_0.root/
+    2Mu2E_500GeV_1p2GeV_1p9mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-1p2_ctau-1p9_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200317_180512/ffNtuple_0.root/
+    2Mu2E_500GeV_1p2GeV_9p6mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-1p2_ctau-9p6_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200322_035907/0000/
+    2Mu2E_500GeV_5GeV_0p08mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-5_ctau-0p08_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200322_040003/0000/
+    2Mu2E_500GeV_5GeV_0p8mm:
+      files:
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-5_ctau-0p8_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200402_184119/0000/
+    2Mu2E_500GeV_5GeV_40mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-5_ctau-40_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200324_145355/0000/
+    2Mu2E_500GeV_5GeV_80mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-5_ctau-80_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200322_040148/0000/
+    2Mu2E_500GeV_5GeV_8mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-5_ctau-8_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_051917/0000/
+    2Mu2E_800GeV_0p25GeV_0p0025mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-0p25_ctau-0p0025_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200322_040243/0000/
+    2Mu2E_800GeV_0p25GeV_0p025mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-0p25_ctau-0p025_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200322_040341/0000/
+    2Mu2E_800GeV_0p25GeV_0p25mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-0p25_ctau-0p25_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_052352/0000/
+    2Mu2E_800GeV_0p25GeV_1p2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-0p25_ctau-1p2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200402_184300/0000/
+    2Mu2E_800GeV_0p25GeV_2p5mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-0p25_ctau-2p5_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_052255/0000/
+    2Mu2E_800GeV_1p2GeV_0p012mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_20.root
+      - ffNtuple_21.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-1p2_ctau-0p012_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_052538/0000/
+    2Mu2E_800GeV_1p2GeV_0p12mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-1p2_ctau-0p12_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_052922/0000/
+    2Mu2E_800GeV_1p2GeV_12mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-1p2_ctau-12_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_052721/0000/
+    2Mu2E_800GeV_1p2GeV_1p2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-1p2_ctau-1p2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200402_184347/0000/
+    2Mu2E_800GeV_1p2GeV_6mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-1p2_ctau-6_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_052627/0000/
+    2Mu2E_800GeV_5GeV_0p05mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-5_ctau-0p05_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_053024/0000/
+    2Mu2E_800GeV_5GeV_0p5mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-5_ctau-0p5_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_053307/0000/
+    2Mu2E_800GeV_5GeV_25mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-5_ctau-25_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v2/200330_144118/0000/
+    2Mu2E_800GeV_5GeV_50mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-5_ctau-50_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_053123/0000/
+    2Mu2E_800GeV_5GeV_5mm:
+      files:
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_20.root
+      - ffNtuple_21.root
+      - ffNtuple_22.root
+      - ffNtuple_23.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-5_ctau-5_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_053210/0000/
+    4Mu_1000GeV_0p25GeV_0p002mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-1000_mA-0p25_ctau-0p002_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200323_183054/0000/
+    4Mu_1000GeV_0p25GeV_0p02mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_20.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-1000_mA-0p25_ctau-0p02_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_042852/0000/
+    4Mu_1000GeV_0p25GeV_0p2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-1000_mA-0p25_ctau-0p2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_042801/0000/
+    4Mu_1000GeV_0p25GeV_1mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-1000_mA-0p25_ctau-1_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_042620/0000/
+    4Mu_1000GeV_0p25GeV_2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-1000_mA-0p25_ctau-2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200402_184530/0000/
+    4Mu_1000GeV_1p2GeV_0p0096mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-1000_mA-1p2_ctau-0p0096_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_042943/0000/
+    4Mu_1000GeV_1p2GeV_0p096mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-1000_mA-1p2_ctau-0p096_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043301/0000/
+    4Mu_1000GeV_1p2GeV_0p96mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-1000_mA-1p2_ctau-0p96_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043214/0000/
+    4Mu_1000GeV_1p2GeV_4p8mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-1000_mA-1p2_ctau-4p8_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043036/0000/
+    4Mu_1000GeV_1p2GeV_9p6mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-1000_mA-1p2_ctau-9p6_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043122/0000/
+    4Mu_1000GeV_5GeV_0p04mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-1000_mA-5_ctau-0p04_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043354/0000/
+    4Mu_1000GeV_5GeV_0p4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-1000_mA-5_ctau-0p4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043705/0000/
+    4Mu_1000GeV_5GeV_20mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-1000_mA-5_ctau-20_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043437/0000/
+    4Mu_1000GeV_5GeV_40mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-1000_mA-5_ctau-40_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043531/0000/
+    4Mu_1000GeV_5GeV_4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-1000_mA-5_ctau-4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043614/0000/
+    4Mu_100GeV_0p25GeV_0p02mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-100_mA-0p25_ctau-0p02_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043749/0000/
+    4Mu_100GeV_0p25GeV_0p2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-100_mA-0p25_ctau-0p2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044101/0000/
+    4Mu_100GeV_0p25GeV_10mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-100_mA-0p25_ctau-10_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043840/0000/
+    4Mu_100GeV_0p25GeV_20mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-100_mA-0p25_ctau-20_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_043924/0000/
+    4Mu_100GeV_0p25GeV_2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-100_mA-0p25_ctau-2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044017/0000/
+    4Mu_100GeV_1p2GeV_0p096mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-100_mA-1p2_ctau-0p096_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044157/0000/
+    4Mu_100GeV_1p2GeV_0p96mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-100_mA-1p2_ctau-0p96_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044515/0000/
+    4Mu_100GeV_1p2GeV_48mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-100_mA-1p2_ctau-48_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044244/0000/
+    4Mu_100GeV_1p2GeV_96mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-100_mA-1p2_ctau-96_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044340/0000/
+    4Mu_100GeV_1p2GeV_9p6mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-100_mA-1p2_ctau-9p6_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044425/0000/
+    4Mu_100GeV_5GeV_0p4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-100_mA-5_ctau-0p4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044559/0000/
+    4Mu_100GeV_5GeV_200mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_20.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-100_mA-5_ctau-200_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044649/0000/
+    4Mu_100GeV_5GeV_400mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_20.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-100_mA-5_ctau-400_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200402_184630/0000/
+    4Mu_100GeV_5GeV_40mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-100_mA-5_ctau-40_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200323_223651/0000/
+    4Mu_100GeV_5GeV_4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_5.root
+      - ffNtuple_7.root
+      path: SIDM_XXTo2ATo4Mu_mXX-100_mA-5_ctau-4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044824/0000/
+    4Mu_150GeV_0p25GeV_0p013mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-150_mA-0p25_ctau-0p013_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200402_184814/0000/
+    4Mu_150GeV_0p25GeV_0p13mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-150_mA-0p25_ctau-0p13_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200330_153256/0000/
+    4Mu_150GeV_0p25GeV_13mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-150_mA-0p25_ctau-13_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045045/0000/
+    4Mu_150GeV_0p25GeV_1p3mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-150_mA-0p25_ctau-1p3_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045144/0000/
+    4Mu_150GeV_0p25GeV_6p7mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-150_mA-0p25_ctau-6p7_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_044959/0000/
+    4Mu_150GeV_1p2GeV_0p064mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-150_mA-1p2_ctau-0p064_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045321/0000/
+    4Mu_150GeV_1p2GeV_0p64mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-150_mA-1p2_ctau-0p64_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045641/0000/
+    4Mu_150GeV_1p2GeV_32mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-150_mA-1p2_ctau-32_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045405/0000/
+    4Mu_150GeV_1p2GeV_64mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-150_mA-1p2_ctau-64_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045456/0000/
+    4Mu_150GeV_1p2GeV_6p4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-150_mA-1p2_ctau-6p4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045537/0000/
+    4Mu_150GeV_5GeV_0p27mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-150_mA-5_ctau-0p27_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045733/0000/
+    4Mu_150GeV_5GeV_130mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_20.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-150_mA-5_ctau-130_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045814/0000/
+    4Mu_150GeV_5GeV_270mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-150_mA-5_ctau-270_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045907/0000/
+    4Mu_150GeV_5GeV_27mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-150_mA-5_ctau-27_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_045949/0000/
+    4Mu_150GeV_5GeV_2p7mm:
+      files:
+      - ffNtuple_1.root
+      path: SIDM_XXTo2ATo4Mu_mXX-150_mA-5_ctau-2p7_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200402_185008/0000/
+    4Mu_200GeV_0p25GeV_0p01mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-200_mA-0p25_ctau-0p01_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200403_193957/0000/
+    4Mu_200GeV_0p25GeV_0p1mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-200_mA-0p25_ctau-0p1_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_050451/0000/
+    4Mu_200GeV_0p25GeV_10mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-200_mA-0p25_ctau-10_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200322_040806/0000/
+    4Mu_200GeV_0p25GeV_1mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-200_mA-0p25_ctau-1_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200322_040858/0000/
+    4Mu_200GeV_0p25GeV_5mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-200_mA-0p25_ctau-5_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200322_040713/0000/
+    4Mu_200GeV_1p2GeV_0p048mm:
+      files:
+      - ffNtuple_1.root
+      path: SIDM_XXTo2ATo4Mu_mXX-200_mA-1p2_ctau-0p048_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_050543/0000/
+    4Mu_200GeV_1p2GeV_0p48mm:
+      files:
+      - ffNtuple_1.root
+      path: SIDM_XXTo2ATo4Mu_mXX-200_mA-1p2_ctau-0p48_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_050900/0000/
+    4Mu_200GeV_1p2GeV_24mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-200_mA-1p2_ctau-24_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200322_040952/0000/
+    4Mu_200GeV_1p2GeV_48mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-200_mA-1p2_ctau-48_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_050726/0000/
+    4Mu_200GeV_1p2GeV_4p8mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-200_mA-1p2_ctau-4p8_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200322_041105/0000/
+    4Mu_200GeV_5GeV_0p2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      path: SIDM_XXTo2ATo4Mu_mXX-200_mA-5_ctau-0p2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200323_183738/0000/
+    4Mu_200GeV_5GeV_100mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-200_mA-5_ctau-100_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_051034/0000/
+    4Mu_200GeV_5GeV_200mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-200_mA-5_ctau-200_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200322_041254/0000/
+    4Mu_200GeV_5GeV_20mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-200_mA-5_ctau-20_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200330_144216/0000/
+    4Mu_200GeV_5GeV_2mm:
+      files:
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      path: SIDM_XXTo2ATo4Mu_mXX-200_mA-5_ctau-2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_051213/0000/
+    4Mu_500GeV_0p25GeV_0p004mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-500_mA-0p25_ctau-0p004_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200322_041347/0000/
+    4Mu_500GeV_0p25GeV_0p04mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-500_mA-0p25_ctau-0p04_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_051615/0000/
+    4Mu_500GeV_0p25GeV_0p4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-500_mA-0p25_ctau-0p4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_051531/0000/
+    4Mu_500GeV_0p25GeV_2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-500_mA-0p25_ctau-2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200323_183930/0000/
+    4Mu_500GeV_0p25GeV_4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-500_mA-0p25_ctau-4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200322_151623/0000/
+    4Mu_500GeV_1p2GeV_0p019mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-500_mA-1p2_ctau-0p019_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200317_180513/ffNtuple_0.root/
+    4Mu_500GeV_1p2GeV_0p19mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-500_mA-1p2_ctau-0p19_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200323_184125/0000/
+    4Mu_500GeV_1p2GeV_19mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-500_mA-1p2_ctau-19_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200317_180513/ffNtuple_0.root/
+    4Mu_500GeV_1p2GeV_1p9mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo4Mu_mXX-500_mA-1p2_ctau-1p9_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200323_184029/0000/
+    4Mu_500GeV_1p2GeV_9p6mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo4Mu_mXX-500_mA-1p2_ctau-9p6_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200317_180513/ffNtuple_0.root/
+    4Mu_500GeV_5GeV_0p08mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      path: SIDM_XXTo2ATo4Mu_mXX-500_mA-5_ctau-0p08_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_051748/0000/
+    4Mu_500GeV_5GeV_0p8mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      path: SIDM_XXTo2ATo4Mu_mXX-500_mA-5_ctau-0p8_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200323_184225/0000/
+    4Mu_500GeV_5GeV_40mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-500_mA-5_ctau-40_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_051841/0000/
+    4Mu_500GeV_5GeV_80mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-500_mA-5_ctau-80_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200317_214820/0000/
+    4Mu_500GeV_5GeV_8mm:
+      files:
+      - ffNtuple_1.root
+      path: SIDM_XXTo2ATo4Mu_mXX-500_mA-5_ctau-8_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200317_214914/0000/
+    4Mu_800GeV_0p25GeV_0p0025mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-800_mA-0p25_ctau-0p0025_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_052200/0000/
+    4Mu_800GeV_0p25GeV_0p025mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      path: SIDM_XXTo2ATo4Mu_mXX-800_mA-0p25_ctau-0p025_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200323_184313/0000/
+    4Mu_800GeV_0p25GeV_0p25mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-800_mA-0p25_ctau-0p25_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_052438/0000/
+    4Mu_800GeV_0p25GeV_1p2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_19.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-800_mA-0p25_ctau-1p2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_052259/0000/
+    4Mu_800GeV_0p25GeV_2p5mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-800_mA-0p25_ctau-2p5_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_052344/0000/
+    4Mu_800GeV_1p2GeV_0p012mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-800_mA-1p2_ctau-0p012_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_052621/0000/
+    4Mu_800GeV_1p2GeV_0p12mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-800_mA-1p2_ctau-0p12_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_052934/0000/
+    4Mu_800GeV_1p2GeV_12mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_17.root
+      - ffNtuple_18.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-800_mA-1p2_ctau-12_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200402_185529/0000/
+    4Mu_800GeV_1p2GeV_1p2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-800_mA-1p2_ctau-1p2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_052843/0000/
+    4Mu_800GeV_1p2GeV_6mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-800_mA-1p2_ctau-6_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_052708/0000/
+    4Mu_800GeV_5GeV_0p05mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-800_mA-5_ctau-0p05_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_053024/0000/
+    4Mu_800GeV_5GeV_0p5mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-800_mA-5_ctau-0p5_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_053338/0000/
+    4Mu_800GeV_5GeV_25mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-800_mA-5_ctau-25_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200321_053118/0000/
+    4Mu_800GeV_5GeV_50mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_13.root
+      - ffNtuple_14.root
+      - ffNtuple_15.root
+      - ffNtuple_16.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-800_mA-5_ctau-50_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200402_185620/0000/
+    4Mu_800GeV_5GeV_5mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_10.root
+      - ffNtuple_11.root
+      - ffNtuple_12.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      - ffNtuple_9.root
+      path: SIDM_XXTo2ATo4Mu_mXX-800_mA-5_ctau-5_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/200323_184624/0000/
 

--- a/sidm/configs/ntuple_locations.yaml
+++ b/sidm/configs/ntuple_locations.yaml
@@ -1,69 +1,728 @@
 # Config to specify paths to all availabe ntuples
-# Currently contains only a few ntuples that were added by hand
-# I intend to add tools that will automatically generate all other entries
+# Automatically generated using sidm/scripts/add_ntuples.py
 
-# Most recent FireFighter ntuples from Weinan -- only includes 2mu2e
+
+#Most recent ntuples from Weinan -- only includes 2mu2e
 ffntuple_v4:
-  path: "root://xcache//store/group/lpcmetx/SIDM/ffNtupleV4/2018/"
+  path: root://cmseos.fnal.gov//store/group/lpcmetx/SIDM/ffNtupleV4/2018/
   samples:
-    2Mu2E_100GeV_1p2GeV_0p096mm:
-      path: "SIDM_XXTo2ATo2Mu2E_mXX-100_mA-1p2_ctau-0p096_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_155855/0000/"
+    2Mu2E_1000GeV_0p25GeV_0p002mm:
       files:
-        - "ffNtuple_1.root"
-        - "ffNtuple_2.root"
-        - "ffNtuple_4.root"
-        - "ffNtuple_5.root"
-    2Mu2E_100GeV_1p2GeV_9p6mm:
-      path: "SIDM_XXTo2ATo2Mu2E_mXX-100_mA-1p2_ctau-9p6_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_161703/0000/"
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-0p25_ctau-0p002_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_155040/0000/
+    2Mu2E_1000GeV_0p25GeV_0p02mm:
       files:
-        - "ffNtuple_1.root"
-        - "ffNtuple_2.root"
-        - "ffNtuple_3.root"
-    2Mu2E_100GeV_5GeV_4mm:
-      path: "SIDM_XXTo2ATo2Mu2E_mXX-100_mA-5_ctau-4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_155809/0000/"
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-0p25_ctau-0p02_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_153302/0000/
+    2Mu2E_1000GeV_0p25GeV_0p2mm:
       files:
-        - "ffNtuple_1.root"
-        - "ffNtuple_2.root"
-        - "ffNtuple_3.root"
-    2Mu2E_150GeV_5GeV_2p7mm:
-      path: "SIDM_XXTo2ATo2Mu2E_mXX-150_mA-5_ctau-2p7_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_155637/0000/"
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-0p25_ctau-0p2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_162212/0000/
+    2Mu2E_1000GeV_0p25GeV_1mm:
       files:
-        - "ffNtuple_1.root"
-        - "ffNtuple_2.root"
-        - "ffNtuple_3.root"
-        - "ffNtuple_4.root"
-        - "ffNtuple_5.root"
-        - "ffNtuple_6.root"
-    2Mu2E_200GeV_5GeV_2mm:
-      path: "SIDM_XXTo2ATo2Mu2E_mXX-200_mA-5_ctau-2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_155722/0000/"
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-0p25_ctau-1_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_160152/0000/
+    2Mu2E_1000GeV_0p25GeV_2mm:
       files:
-        - "ffNtuple_1.root"
-        - "ffNtuple_2.root"
-        - "ffNtuple_3.root"
-    2Mu2E_500GeV_5GeV_0p8mm:
-      path: "SIDM_XXTo2ATo2Mu2E_mXX-500_mA-5_ctau-0p8_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_160450/0000/"
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-0p25_ctau-2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_152819/0000/
+    2Mu2E_1000GeV_1p2GeV_0p0096mm:
       files:
-        - "ffNtuple_1.root"
-        - "ffNtuple_2.root"
-        - "ffNtuple_3.root"
-        - "ffNtuple_4.root"
-        - "ffNtuple_5.root"
-        - "ffNtuple_6.root"
-        - "ffNtuple_7.root"
-    2Mu2E_800GeV_5GeV_0p5mm:
-      path: "SIDM_XXTo2ATo2Mu2E_mXX-800_mA-5_ctau-0p5_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_153128/0000/"
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-1p2_ctau-0p0096_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_162000/0000/
+    2Mu2E_1000GeV_1p2GeV_0p096mm:
       files:
-        - "ffNtuple_1.root"
-        - "ffNtuple_2.root"
-        - "ffNtuple_3.root"
-        - "ffNtuple_4.root"
-        - "ffNtuple_5.root"
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-1p2_ctau-0p096_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_153732/0000/
+    2Mu2E_1000GeV_1p2GeV_0p96mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-1p2_ctau-0p96_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_154112/0000/
+    2Mu2E_1000GeV_1p2GeV_4p8mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-1p2_ctau-4p8_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_160925/0000/
+    2Mu2E_1000GeV_1p2GeV_9p6mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-1p2_ctau-9p6_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_155256/0000/
+    2Mu2E_1000GeV_5GeV_0p04mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-5_ctau-0p04_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_162044/0000/
     2Mu2E_1000GeV_5GeV_0p4mm:
-      path: "SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-5_ctau-0p4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_154240/0000/"
       files:
-        - "ffNtuple_1.root"
-        - "ffNtuple_2.root"
-        - "ffNtuple_3.root"
-        - "ffNtuple_4.root"
-        - "ffNtuple_5.root"
-        - "ffNtuple_6.root"
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-5_ctau-0p4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_154240/0000/
+    2Mu2E_1000GeV_5GeV_20mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-5_ctau-20_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_195440/0000/
+    2Mu2E_1000GeV_5GeV_40mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-5_ctau-40_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_195553/0000/
+    2Mu2E_1000GeV_5GeV_4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-1000_mA-5_ctau-4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_154725/0000/
+    2Mu2E_100GeV_0p25GeV_0p02mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-0p25_ctau-0p02_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_153435/0000/
+    2Mu2E_100GeV_0p25GeV_0p2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-0p25_ctau-0p2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_161009/0000/
+    2Mu2E_100GeV_0p25GeV_10mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-0p25_ctau-10_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_152735/0000/
+    2Mu2E_100GeV_0p25GeV_20mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-0p25_ctau-20_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_153943/0000/
+    2Mu2E_100GeV_0p25GeV_2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-0p25_ctau-2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_154556/0000/
+    2Mu2E_100GeV_1p2GeV_0p096mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-1p2_ctau-0p096_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_155855/0000/
+    2Mu2E_100GeV_1p2GeV_0p96mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-1p2_ctau-0p96_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_152341/0000/
+    2Mu2E_100GeV_1p2GeV_48mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-1p2_ctau-48_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_152045/0000/
+    2Mu2E_100GeV_1p2GeV_96mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-1p2_ctau-96_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_155339/0000/
+    2Mu2E_100GeV_1p2GeV_9p6mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-1p2_ctau-9p6_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_161703/0000/
+    2Mu2E_100GeV_5GeV_0p4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-5_ctau-0p4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_160618/0000/
+    2Mu2E_100GeV_5GeV_200mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-5_ctau-200_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_152129/0000/
+    2Mu2E_100GeV_5GeV_400mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-5_ctau-400_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_160321/0000/
+    2Mu2E_100GeV_5GeV_40mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-5_ctau-40_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_161308/0000/
+    2Mu2E_100GeV_5GeV_4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-100_mA-5_ctau-4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_155809/0000/
+    2Mu2E_150GeV_0p25GeV_0p013mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-0p25_ctau-0p013_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_161618/0000/
+    2Mu2E_150GeV_0p25GeV_0p13mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-0p25_ctau-0p13_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_152427/0000/
+    2Mu2E_150GeV_0p25GeV_13mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-0p25_ctau-13_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_154815/0000/
+    2Mu2E_150GeV_0p25GeV_1p3mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-0p25_ctau-1p3_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_153859/0000/
+    2Mu2E_150GeV_0p25GeV_6p7mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-0p25_ctau-6p7_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_161403/0000/
+    2Mu2E_150GeV_1p2GeV_0p064mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-1p2_ctau-0p064_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_152947/0000/
+    2Mu2E_150GeV_1p2GeV_0p64mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-1p2_ctau-0p64_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_152257/0000/
+    2Mu2E_150GeV_1p2GeV_32mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-1p2_ctau-32_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_195516/0000/
+    2Mu2E_150GeV_1p2GeV_64mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-1p2_ctau-64_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_161832/0000/
+    2Mu2E_150GeV_1p2GeV_6p4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-1p2_ctau-6p4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_153518/0000/
+    2Mu2E_150GeV_5GeV_0p27mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-5_ctau-0p27_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_161140/0000/
+    2Mu2E_150GeV_5GeV_130mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-5_ctau-130_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_153815/0000/
+    2Mu2E_150GeV_5GeV_270mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-5_ctau-270_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_152607/0000/
+    2Mu2E_150GeV_5GeV_27mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-5_ctau-27_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_154410/0000/
+    2Mu2E_150GeV_5GeV_2p7mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-150_mA-5_ctau-2p7_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_155637/0000/
+    2Mu2E_200GeV_0p25GeV_0p01mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-0p25_ctau-0p01_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_154326/0000/
+    2Mu2E_200GeV_0p25GeV_0p1mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-0p25_ctau-0p1_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_161057/0000/
+    2Mu2E_200GeV_0p25GeV_10mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-0p25_ctau-10_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_153044/0000/
+    2Mu2E_200GeV_0p25GeV_1mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-0p25_ctau-1_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_161449/0000/
+    2Mu2E_200GeV_0p25GeV_5mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-0p25_ctau-5_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_153347/0000/
+    2Mu2E_200GeV_1p2GeV_0p048mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-1p2_ctau-0p048_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_155508/0000/
+    2Mu2E_200GeV_1p2GeV_0p48mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-1p2_ctau-0p48_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_154950/0000/
+    2Mu2E_200GeV_1p2GeV_24mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-1p2_ctau-24_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_154157/0000/
+    2Mu2E_200GeV_1p2GeV_48mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-1p2_ctau-48_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_162640/0000/
+    2Mu2E_200GeV_1p2GeV_4p8mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-1p2_ctau-4p8_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_162556/0000/
+    2Mu2E_200GeV_5GeV_0p2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-5_ctau-0p2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_155208/0000/
+    2Mu2E_200GeV_5GeV_100mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-5_ctau-100_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_162128/0000/
+    2Mu2E_200GeV_5GeV_200mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-5_ctau-200_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_160757/0000/
+    2Mu2E_200GeV_5GeV_20mm:
+      files:
+      - ffNtuple_1.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-5_ctau-20_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_151951/0000/
+    2Mu2E_200GeV_5GeV_2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-200_mA-5_ctau-2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_155722/0000/
+    2Mu2E_500GeV_0p25GeV_0p004mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-0p25_ctau-0p004_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_153213/0000/
+    2Mu2E_500GeV_0p25GeV_0p04mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-0p25_ctau-0p04_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_153648/0000/
+    2Mu2E_500GeV_0p25GeV_0p4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-0p25_ctau-0p4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_161225/0000/
+    2Mu2E_500GeV_0p25GeV_2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-0p25_ctau-2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_160236/0000/
+    2Mu2E_500GeV_0p25GeV_4mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-0p25_ctau-4_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_154509/0000/
+    2Mu2E_500GeV_1p2GeV_0p019mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-1p2_ctau-0p019_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_162426/0000/
+    2Mu2E_500GeV_1p2GeV_0p19mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-1p2_ctau-0p19_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_154905/0000/
+    2Mu2E_500GeV_1p2GeV_19mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-1p2_ctau-19_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_160107/0000/
+    2Mu2E_500GeV_1p2GeV_1p9mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-1p2_ctau-1p9_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_160841/0000/
+    2Mu2E_500GeV_1p2GeV_9p6mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-1p2_ctau-9p6_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_151905/0000/
+    2Mu2E_500GeV_5GeV_0p08mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-5_ctau-0p08_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_195629/0000/
+    2Mu2E_500GeV_5GeV_0p8mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-5_ctau-0p8_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_160450/0000/
+    2Mu2E_500GeV_5GeV_40mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-5_ctau-40_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_155939/0000/
+    2Mu2E_500GeV_5GeV_80mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-5_ctau-80_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_152522/0000/
+    2Mu2E_500GeV_5GeV_8mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-500_mA-5_ctau-8_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_154028/0000/
+    2Mu2E_800GeV_0p25GeV_0p0025mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-0p25_ctau-0p0025_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_162257/0000/
+    2Mu2E_800GeV_0p25GeV_0p025mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-0p25_ctau-0p025_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_155553/0000/
+    2Mu2E_800GeV_0p25GeV_0p25mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-0p25_ctau-0p25_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_153602/0000/
+    2Mu2E_800GeV_0p25GeV_1p2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-0p25_ctau-1p2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_161534/0000/
+    2Mu2E_800GeV_0p25GeV_2p5mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-0p25_ctau-2p5_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_161915/0000/
+    2Mu2E_800GeV_1p2GeV_0p012mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-1p2_ctau-0p012_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_160702/0000/
+    2Mu2E_800GeV_1p2GeV_0p12mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-1p2_ctau-0p12_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_162509/0000/
+    2Mu2E_800GeV_1p2GeV_12mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-1p2_ctau-12_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_160405/0000/
+    2Mu2E_800GeV_1p2GeV_1p2mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-1p2_ctau-1p2_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_152651/0000/
+    2Mu2E_800GeV_1p2GeV_6mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-1p2_ctau-6_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_155424/0000/
+    2Mu2E_800GeV_5GeV_0p05mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-5_ctau-0p05_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_161747/0000/
+    2Mu2E_800GeV_5GeV_0p5mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-5_ctau-0p5_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_153128/0000/
+    2Mu2E_800GeV_5GeV_25mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-5_ctau-25_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v2/210326_155125/0000/
+    2Mu2E_800GeV_5GeV_50mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-5_ctau-50_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_160534/0000/
+    2Mu2E_800GeV_5GeV_5mm:
+      files:
+      - ffNtuple_1.root
+      - ffNtuple_2.root
+      - ffNtuple_3.root
+      - ffNtuple_4.root
+      - ffNtuple_5.root
+      - ffNtuple_6.root
+      - ffNtuple_7.root
+      - ffNtuple_8.root
+      path: SIDM_XXTo2ATo2Mu2E_mXX-800_mA-5_ctau-5_TuneCP5_13TeV-madgraph-pythia8/RunIIAutumn18DRPremix-102X_upgrade2018_realistic_v15-v1/210326_152214/0000/
+

--- a/sidm/scripts/add_ntuples.py
+++ b/sidm/scripts/add_ntuples.py
@@ -1,0 +1,105 @@
+# Tool to add ntuple locations to sidm/configs/ntuple_locations.yaml. Developed and tested on FNAL
+# LPC. Will be updated after issue https://github.com/CoffeaTeam/coffea-casa/issues/374 is
+# resolved. Note that cmsenv or equivalent is needed to import XRootD.
+
+# Usage: python add_ntuples.py -o OUTPUT_CONFIG -n NTUPLE_NAME -c NTUPLE_COMMENT -d NTUPLE_ROOT_DIR
+
+from __future__ import print_function
+import argparse
+import yaml
+from XRootD import client
+
+
+def parse_name(name):
+    """Parse sample directory name to produce simplified name
+    
+    Assumes structure like "SIDM_XXTo2ATo2Mu2E_mXX-100_mA-1p2_ctau-0p096_TuneCP..."
+    """
+
+    process_names = {
+        "SIDM_XXTo2ATo2Mu2E_mXX": "2Mu2E_",
+        # fixme: add 4mu and backgrounds as necessary
+    }
+    chunks = name.split("-")
+    simplified_name = process_names[chunks[0]] # process name
+    simplified_name += chunks[1].replace("_mA", "GeV_") # bound state mass
+    simplified_name += chunks[2].replace("_ctau", "GeV_") # dark photon mass
+    simplified_name += chunks[3].split("_TuneCP")[0] + "mm" # dark photon ctau
+
+    return(simplified_name)
+
+def descend(ntuple_path, sample_path):
+    path = ntuple_path + "/" + sample_path
+    dir_contents = xrd_client.dirlist(path)[1]
+    num_found = dir_contents.size
+
+    # Handle emtpy directories
+    if num_found == 0:
+        print("Found zero objects in {}. Skipping.".format(path))
+        return None
+
+    # Allow user to choose directory if more than one is found
+    if num_found > 1:
+        print("Unexpected directory structure. Found {} objects in {}".format(num_found, path))
+        print("Please type the number of the directory you would like to use. Options are:")
+        for i, x in enumerate(dir_contents):
+            print(i, x.name)
+        dir_ix = input() # fixme: check input
+    else:
+        dir_ix = 0
+
+    return sample_path + "/" + dir_contents.dirlist[dir_ix].name
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-o", "--output_cfg", dest="cfg", required=True,
+                    help="Path to output config, e.g. '../configs/ntuple_locations.yaml'")
+parser.add_argument("-n", "--name", dest="name", required=True,
+                    help="Name of group of ntuples, e.g. 'ffntuple_v4'")
+parser.add_argument("-c", "--comment", dest="comment", required=True,
+                    help=("Comment to describe group of ntuples, e.g. "
+                          "'Most recent ntuples from Weinan -- only includes 2mu2e'"))
+parser.add_argument("-d", "--directory", dest="directory", required=True,
+                    help=("Path to ntuple root directory, e.g. "
+                    "'root://cmseos.fnal.gov//store/group/lpcmetx/SIDM/ffNtupleV4/2018/'"))
+args = parser.parse_args()
+
+# Set up xrd client
+redirector = args.directory.split("//store")[0]
+xrd_client = client.FileSystem(redirector)
+
+output = {
+    args.name: {
+        "path": args.directory,
+        "samples": {}
+    }
+}
+ntuple_path = args.directory.split(redirector)[1]
+samples = xrd_client.dirlist(ntuple_path)[1]
+
+# Traverse ntuple directory and construct output dictionary
+# Assumes same structure as root://cmseos.fnal.gov//store/group/lpcmetx/SIDM/ffNtupleV4/2018/
+for sample in samples:
+    if sample.name.endswith("tmp"): # fixme: would be better to check if dir
+        continue
+    simple_name = parse_name(sample.name)
+    output[args.name]["samples"][simple_name] = {}
+    sample_path = sample.name
+
+    # Descend three layers, expecting to find a single directory at each
+    try:
+        for _ in range(3):
+            sample_path = descend(ntuple_path, sample_path)
+            if sample_path is None:
+                raise StopIteration()
+    except StopIteration:
+        continue
+
+    # If traversal was successful, add path and files to output dictionary
+    output[args.name]["samples"][simple_name]["path"] = sample_path + "/"
+    files = [f.name for f in xrd_client.dirlist(ntuple_path + sample_path)[1]]
+    output[args.name]["samples"][simple_name]["files"] = files
+
+with open('test.yaml', 'a') as out_file:
+    out_file.write("\n\n#" + args.comment + "\n")
+    yaml.dump(output, out_file, default_flow_style=False)

--- a/sidm/scripts/add_ntuples.py
+++ b/sidm/scripts/add_ntuples.py
@@ -69,10 +69,11 @@ def descend(ntuple_path, sample_path):
 redirector = args.directory.split("//store")[0]
 xrd_client = client.FileSystem(redirector)
 
+coffea_casa_dir = args.directory.replace("cmseos.fnal.gov", "xcache")
 output = {
     args.name: {
-        "path": args.directory,
-        "samples": {}
+        "path": coffea_casa_dir,
+        "samples": {},
     }
 }
 ntuple_path = args.directory.split(redirector)[1]

--- a/sidm/scripts/add_ntuples.py
+++ b/sidm/scripts/add_ntuples.py
@@ -10,6 +10,20 @@ import yaml
 from XRootD import client
 
 
+parser = argparse.ArgumentParser()
+parser.add_argument("-o", "--output_cfg", dest="cfg", required=True,
+                    help="Path to output config, e.g. '../configs/ntuple_locations.yaml'")
+parser.add_argument("-n", "--name", dest="name", required=True,
+                    help="Name of group of ntuples, e.g. 'ffntuple_v4'")
+parser.add_argument("-c", "--comment", dest="comment", required=True,
+                    help=("Comment to describe group of ntuples, e.g. "
+                          "'Most recent ntuples from Weinan -- only includes 2mu2e'"))
+parser.add_argument("-d", "--directory", dest="directory", required=True,
+                    help=("Path to ntuple root directory, e.g. "
+                    "'root://cmseos.fnal.gov//store/group/lpcmetx/SIDM/ffNtupleV4/2018/'"))
+args = parser.parse_args()
+
+
 def parse_name(name):
     """Parse sample directory name to produce simplified name
     
@@ -51,19 +65,6 @@ def descend(ntuple_path, sample_path):
     return sample_path + "/" + dir_contents.dirlist[dir_ix].name
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument("-o", "--output_cfg", dest="cfg", required=True,
-                    help="Path to output config, e.g. '../configs/ntuple_locations.yaml'")
-parser.add_argument("-n", "--name", dest="name", required=True,
-                    help="Name of group of ntuples, e.g. 'ffntuple_v4'")
-parser.add_argument("-c", "--comment", dest="comment", required=True,
-                    help=("Comment to describe group of ntuples, e.g. "
-                          "'Most recent ntuples from Weinan -- only includes 2mu2e'"))
-parser.add_argument("-d", "--directory", dest="directory", required=True,
-                    help=("Path to ntuple root directory, e.g. "
-                    "'root://cmseos.fnal.gov//store/group/lpcmetx/SIDM/ffNtupleV4/2018/'"))
-args = parser.parse_args()
-
 # Set up xrd client
 redirector = args.directory.split("//store")[0]
 xrd_client = client.FileSystem(redirector)
@@ -100,6 +101,7 @@ for sample in samples:
     files = [f.name for f in xrd_client.dirlist(ntuple_path + sample_path)[1]]
     output[args.name]["samples"][simple_name]["files"] = files
 
-with open('test.yaml', 'a') as out_file:
+with open(args.cfg, 'a') as out_file:
     out_file.write("\n\n#" + args.comment + "\n")
     yaml.dump(output, out_file, default_flow_style=False)
+    out_file.write("\n")

--- a/sidm/tools/utilities.py
+++ b/sidm/tools/utilities.py
@@ -72,6 +72,8 @@ def load_yaml(cfg):
 
 def make_fileset(samples, ntuple_version, location_cfg="../configs/ntuple_locations.yaml"):
     """Make fileset to pass to processor.runner"""
+    if ntuple_version != "ffntuple_v4":
+        raise NotImplementedError("Only ffntuple_v4 ntuples have been implemented")
     locations = load_yaml(location_cfg)[ntuple_version]
     fileset = {}
     for sample in samples:


### PR DESCRIPTION
This PR adds a script to automatically popluate ntuple_locations.yaml. It must be run on fnal lpc, and currently only handles SIDM signal samples, though the changes necessary to handle bg samples are minimal.

It has been run over v2 and v4 ntuples from Weinan, so ntuple_locations.yaml now includes all v2 and v4 2Mu2E and 4Mu ntuples. The v2 ntuples require modifications to ffschema, so protection has been added to only allow use of v4 ntuples.

I plan to merge this PR to allow access to all v4 ntuples and the script, but the script will require further updates to work with more samples that may have different directory structures.