### PR TITLE
Add baseline cuts for objects

### DIFF
--- a/sidm/configs/selections.yaml
+++ b/sidm/configs/selections.yaml
@@ -4,8 +4,36 @@
 # Any nested collections created by "<<" or '*' operations will be flattened in sidm_processor.py
 
 
+# Cuts to apply to objects that are clustered into lepton jets
+ljsource_cuts: &ljsource_cuts
+    obj_cuts: &obj_ljsource_cuts
+      electrons: 
+        - "pT > 10 GeV"
+        - "|eta| < 2.4"
+        - "looseID"
+      muons: 
+        - "looseID"
+        - "pT > 5 GeV"
+        - "|eta| < 2.4"
+      photons:
+        - "pT > 20 GeV"
+        - "|eta| < 2.5"
+        - "looseID"
+      dsamuons: 
+        - "pT > 10 GeV"
+        - "|eta| < 2.4"
+        - "ifcsczero"
+        - "segOverlap < 0.66"
+        - "extrapolatedDr > 0.2" 
+        - "isSubsetAnyPFMuon False"
+        - "normChi2 < 4"
+        - "DT + CSC hits > 12"
+        - "DT + CSC stations >= 2"
+        - "ptErrorOverPT < 1"
+
 # basic analysis selections
 baseNoLj: &baseNoLj
+  << : *ljsource_cuts
   obj_cuts: &obj_baseNoLj
     pvs: &pv_baseNoLj
       - "ndof > 4"
@@ -16,6 +44,7 @@ baseNoLj: &baseNoLj
     - "Cosmic veto"
 
 base: &base
+  << : *ljsource_cuts
   obj_cuts: &obj_base
     <<: *obj_baseNoLj
     ljs: &lj_base

--- a/sidm/definitions/cuts.py
+++ b/sidm/definitions/cuts.py
@@ -23,6 +23,37 @@ obj_cut_defs = {
         "lxy < 10 cm": lambda objs: lxy(objs["genAs"]) < 10,
         "10 cm <= lxy < 100 cm": lambda objs: (lxy(objs["genAs"]) >= 10) & (lxy(objs["genAs"]) < 100),
         "lxy >= 100 cm": lambda objs: lxy(objs["genAs"]) >= 100,
+    },
+    "electrons": {
+        "pT > 10 GeV": lambda objs: objs["electrons"].pt > 10,
+        "|eta| < 2.4": lambda objs: abs(objs["electrons"].eta) < 2.4,
+        #Loose ID = bit 1
+        "looseID": lambda objs: (objs["electrons"].idResults & 2) == True
+    },
+    "muons": {
+        #Loose ID = bit 0
+        #See https://gitlab.cern.ch/areinsvo/Firefighter/-/blob/master/ffNtuple/plugins/ffNtupleMuon.cc 
+        "looseID": lambda objs: (objs["muons"].selectors  & 1) == True,
+        "pT > 5 GeV": lambda objs: objs["muons"].pt > 5,
+        "|eta| < 2.4": lambda objs: abs(objs["muons"].eta) < 2.4
+    },
+    "photons":{
+        "pT > 20 GeV": lambda objs: objs["photons"].pt > 20,
+        "|eta| < 2.5": lambda objs: abs(objs["photons"].scEta) < 2.5,
+        #Loose ID = bit 0
+        "looseID": lambda objs: (objs["photons"].idResults & 1) == True
+    },
+    "dsamuons": {
+        "pT > 10 GeV": lambda objs: objs["dsaMuons"].pt > 10,
+        "|eta| < 2.4": lambda objs: abs(objs["dsaMuons"].eta) < 2.4,
+        "ifcsczero": lambda objs: ak.where(((objs["dsaMuons"].CSCHits==0) & (objs["dsaMuons"].DTHits<=18)), False, True),
+        "segOverlap < 0.66": lambda objs: objs["dsaMuons"].segOverlapRatio < 0.66,
+        "extrapolatedDr > 0.2": lambda objs: objs["dsaMuons"].extrapolatedDr > 0.2, 
+        "isSubsetAnyPFMuon False": lambda objs: objs["dsaMuons"].isSubsetAnyPFMuon == 0,
+        "normChi2 < 4": lambda objs: objs["dsaMuons"].normChi2 < 4,
+        "DT + CSC hits > 12": lambda objs: (objs["dsaMuons"].DTHits + objs["dsaMuons"].CSCHits) > 12,
+        "DT + CSC stations >= 2": lambda objs: (objs["dsaMuons"].DTStations + objs["dsaMuons"].CSCStations) >= 2,
+        "ptErrorOverPT < 1": lambda objs: objs["dsaMuons"].ptErrorOverPt <1.0
     }
 }
 


### PR DESCRIPTION
Adding cuts to the electron, photon, dsa muon, and muon collections to try to match what was in the old AN. The cuts to electrons and photons might need to be revisited to exactly match what is done in the ntuplizer to get the ljsource collection, but this is at least a good start.

Notice that these cuts are now applied to `base` and so will probably affects lots of the other plots that we have made in other notebooks!