### PR TITLE
Fixes pT ordering issue in processor, reruns leptonKinematics

### DIFF
--- a/sidm/studies/leptonKinematics.ipynb
+++ b/sidm/studies/leptonKinematics.ipynb
@@ -69,7 +69,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4142cbb7c5f640beacfa5f22c6a143dc",
+       "model_id": "fa2c84df9bfb419089c9924cdae69345",
        "version_major": 2,
        "version_minor": 0
       },
@@ -106,7 +106,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "05f3100f69eb4dbe89d859d8e8aac6b7",
+       "model_id": "6135740580b04add92ecdf1e8a03372f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -116,6 +116,37 @@
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n"
+     ]
     },
     {
      "data": {
@@ -156,7 +187,7 @@
     "    #executor=processor.IterativeExecutor(),\n",
     "    executor=processor.FuturesExecutor(),\n",
     "    schema=ffschema.FFSchema,\n",
-    "    #maxchunks=1,\n",
+    "    # maxchunks=1,\n",
     ")\n",
     "\n",
     "channels = [\"baseNoLj\"]\n",
@@ -399,7 +430,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "02a91f45dbeb4a7392ecbc4fe1443af8",
+       "model_id": "31ec73c76b464f82989c7b2d665e9bfe",
        "version_major": 2,
        "version_minor": 0
       },
@@ -436,7 +467,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bf413b81c7c44241beb0f78041db7ad2",
+       "model_id": "02e724168e2546ab9f95df236706e3d7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -446,6 +477,28 @@
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n",
+      "Not applying any cuts to the lepton jets for channel  baseNoLj\n"
+     ]
     },
     {
      "data": {
@@ -638,7 +691,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.17"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,

--- a/sidm/tools/sidm_processor.py
+++ b/sidm/tools/sidm_processor.py
@@ -315,7 +315,7 @@ class SidmProcessor(processor.ProcessorABC):
     def order(self, obj):
         """Explicitly order objects"""
         # pt order objects with a pt attribute
-        if hasattr(obj, "p4"):
+        if hasattr(obj, "pt"):
             obj = obj[ak.argsort(obj.pt, ascending=False)]
         # fixme: would be good to explicitly order other objects as well
         return obj


### PR DESCRIPTION
This changes the ordering on objects by p4 (which has been replaced) to the pt attribute. It also seems to change the "version" number in leptonKinematics.ipynb, but I'm not able to find where this is actually placed in the file.