### PR TITLE
Demonstrate how to save processor output to a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+#Coffea output files
+*.coffea
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/sidm/test_notebooks/save_output.ipynb
+++ b/sidm/test_notebooks/save_output.ipynb
@@ -1,0 +1,568 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f8cfbf6a-4a99-4a82-96a1-6c36529d5ee5",
+   "metadata": {},
+   "source": [
+    "# Saving coffea output to a file\n",
+    "\n",
+    "This notebook demonstrates how to save the coffea output to a file, which can then be loaded again (e.g. if the kernel fails unexpectedly or if only some datasets are processed successfully). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "59bfb7a1-31a5-403d-a3d1-04683777678e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# python\n",
+    "import sys\n",
+    "import os\n",
+    "import importlib\n",
+    "# columnar analysis\n",
+    "from coffea import processor\n",
+    "from coffea.nanoevents import NanoAODSchema\n",
+    "import awkward as ak\n",
+    "from dask.distributed import Client, performance_report\n",
+    "# local\n",
+    "sidm_path=str(os.getcwd()).split(\"/sidm\")[0]\n",
+    "if sidm_path not in sys.path: sys.path.insert(1, sidm_path)\n",
+    "os.makedirs(f\"{sidm_path}/plots\",exist_ok=True)\n",
+    "from sidm.tools import utilities, sidm_processor, scaleout\n",
+    "# always reload local modules to pick up changes during development\n",
+    "importlib.reload(utilities)\n",
+    "importlib.reload(sidm_processor)\n",
+    "importlib.reload(scaleout)\n",
+    "# plotting\n",
+    "import matplotlib.pyplot as plt\n",
+    "utilities.set_plot_style()\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ffbfb96-cfbf-461f-b640-7bb4e7d74a5d",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "Additional import needed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7fabfa56-86f2-455d-9e1e-81024b823fb3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import coffea.util"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "059c1290-4190-4958-8a6a-4eadc921fb98",
+   "metadata": {},
+   "source": [
+    "Define samples and channels here so the lists can be used either if we are creating the output from scratch or loading it from files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "af852758-4875-41f7-8a22-d9ccb65c711e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "samples = [\n",
+    "    \"2Mu2E_100GeV_1p2GeV_9p6mm\",\n",
+    "     \"2Mu2E_150GeV_1p2GeV_6p4mm\",\n",
+    "     \"2Mu2E_200GeV_1p2GeV_4p8mm\",\n",
+    "]\n",
+    "\n",
+    "channels = [\n",
+    "    \"baseNoLj\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37e3ed03-1410-499e-861a-df26b691ae39",
+   "metadata": {},
+   "source": [
+    "## Run the processor and save outputs\n",
+    "Run over three signal samples separately, saving the output of the processor to a file each time. The format of the output file is pickle file. See documentation here https://coffea-hep.readthedocs.io/en/latest/api/coffea.util.save.html#coffea.util.save\n",
+    "\n",
+    "Use the .coffea file extension for the outputs; this way we know that it's a processor output file, and then git knows to ignore it (we never want a pickled coffea file to be pushed to the repo!!)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1312f852-e018-4808-90dc-8ef0dce8fe27",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "903f68f6ab974be8bc8b775037d96081",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Processing 2Mu2E_100GeV_1p2GeV_9p6mm\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bcbc628b64244fcf89c2e2eddce9d527",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">/usr/local/lib/python3.10/site-packages/coffea/nanoevents/schemas/nanoaod.py:205: RuntimeWarning: Missing \n",
+       "cross-reference index for LowPtElectron_electronIdx =&gt; Electron\n",
+       "  warnings.warn(\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "/usr/local/lib/python3.10/site-packages/coffea/nanoevents/schemas/nanoaod.py:205: RuntimeWarning: Missing \n",
+       "cross-reference index for LowPtElectron_electronIdx => Electron\n",
+       "  warnings.warn(\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">/usr/local/lib/python3.10/site-packages/coffea/nanoevents/schemas/nanoaod.py:205: RuntimeWarning: Missing \n",
+       "cross-reference index for LowPtElectron_photonIdx =&gt; Photon\n",
+       "  warnings.warn(\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "/usr/local/lib/python3.10/site-packages/coffea/nanoevents/schemas/nanoaod.py:205: RuntimeWarning: Missing \n",
+       "cross-reference index for LowPtElectron_photonIdx => Photon\n",
+       "  warnings.warn(\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">/usr/local/lib/python3.10/site-packages/awkward/_connect/_numpy.py:197: RuntimeWarning: invalid value encountered \n",
+       "in divide\n",
+       "  result = getattr(ufunc, method)(\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "/usr/local/lib/python3.10/site-packages/awkward/_connect/_numpy.py:197: RuntimeWarning: invalid value encountered \n",
+       "in divide\n",
+       "  result = getattr(ufunc, method)(\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#--------------------------------------------------------------------------\n",
+      "#                         FastJet release 3.4.0\n",
+      "#                 M. Cacciari, G.P. Salam and G. Soyez                  \n",
+      "#     A software package for jet finding and analysis at colliders      \n",
+      "#                           http://fastjet.fr                           \n",
+      "#\t                                                                      \n",
+      "# Please cite EPJC72(2012)1896 [arXiv:1111.6097] if you use this package\n",
+      "# for scientific work and optionally PLB641(2006)57 [hep-ph/0512210].   \n",
+      "#                                                                       \n",
+      "# FastJet is provided without warranty under the GNU GPL v2 or higher.  \n",
+      "# It uses T. Chan's closest pair algorithm, S. Fortune's Voronoi code,\n",
+      "# CGAL and 3rd party plugin jet algorithms. See COPYING file for details.\n",
+      "#--------------------------------------------------------------------------\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "20154aa7c76e490cb5987a74cbce97ed",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Signal not in xs cfg, assuming 1fb\n",
+      "Processing 2Mu2E_150GeV_1p2GeV_6p4mm\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dd7328811cba4484b85382c4338c5bc3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">/usr/local/lib/python3.10/site-packages/coffea/nanoevents/schemas/nanoaod.py:205: RuntimeWarning: Missing \n",
+       "cross-reference index for LowPtElectron_electronIdx =&gt; Electron\n",
+       "  warnings.warn(\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "/usr/local/lib/python3.10/site-packages/coffea/nanoevents/schemas/nanoaod.py:205: RuntimeWarning: Missing \n",
+       "cross-reference index for LowPtElectron_electronIdx => Electron\n",
+       "  warnings.warn(\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">/usr/local/lib/python3.10/site-packages/coffea/nanoevents/schemas/nanoaod.py:205: RuntimeWarning: Missing \n",
+       "cross-reference index for LowPtElectron_photonIdx =&gt; Photon\n",
+       "  warnings.warn(\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "/usr/local/lib/python3.10/site-packages/coffea/nanoevents/schemas/nanoaod.py:205: RuntimeWarning: Missing \n",
+       "cross-reference index for LowPtElectron_photonIdx => Photon\n",
+       "  warnings.warn(\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6db10a81e7f14286a92ecd8e1befa2d0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Signal not in xs cfg, assuming 1fb\n",
+      "Processing 2Mu2E_200GeV_1p2GeV_4p8mm\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "97082f69159240028489865f5c8c863d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Signal not in xs cfg, assuming 1fb\n"
+     ]
+    }
+   ],
+   "source": [
+    "fileset = utilities.make_fileset(samples, \"llpNanoAOD_v2\", max_files=2, location_cfg=\"signal_2mu2e_v10.yaml\")\n",
+    "\n",
+    "runner = processor.Runner(\n",
+    "    executor=processor.IterativeExecutor(),\n",
+    "    schema=NanoAODSchema,\n",
+    "    maxchunks=1,\n",
+    "    skipbadfiles=True\n",
+    ")\n",
+    "\n",
+    "p = sidm_processor.SidmProcessor(\n",
+    "    channels,\n",
+    "    [\"genA_base\"],\n",
+    "    #verbose=True,\n",
+    ")\n",
+    "\n",
+    "out = {}\n",
+    "\n",
+    "for i, sample in enumerate(samples):\n",
+    "\n",
+    "    print(f\"Processing {sample}\")\n",
+    "    fileset_one_sample = {samples[i]:fileset.get(samples[i])}\n",
+    "    \n",
+    "    output = runner.run(fileset_one_sample, treename='Events', processor_instance=p)\n",
+    "\n",
+    "    #Add this sample's output to the out variable\n",
+    "    out[sample] = output[\"out\"][sample]\n",
+    "\n",
+    "    ##Save output to a file!!\n",
+    "    out_file_name = \"output_\" + sample + \".coffea\"\n",
+    "    coffea.util.save(output,out_file_name)\n",
+    "\n",
+    "##The variable _out_ should be equivalent to the normal method of running all the samples at once, e.g:\n",
+    "#output = runner.run(fileset, treename='Events', processor_instance=p)\n",
+    "#out2 = output[\"out\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e796d06d-3790-462f-b6e3-270fb1a0174e",
+   "metadata": {},
+   "source": [
+    "## Check which coffea files were created:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "de7f647b-916c-4e4a-a908-be62ce06890e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "output_2Mu2E_200GeV_1p2GeV_4p8mm.coffea\n",
+      "output_2Mu2E_150GeV_1p2GeV_6p4mm.coffea\n",
+      "output_2Mu2E_100GeV_1p2GeV_9p6mm.coffea\n"
+     ]
+    }
+   ],
+   "source": [
+    "for file in os.listdir(): \n",
+    "    if file.endswith(\".coffea\"): print(file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67c3a7f0-d405-4ed8-a6ed-8589e13503f1",
+   "metadata": {},
+   "source": [
+    "# Demonstrate loading the files\n",
+    "\n",
+    "Assuming the files follow the output_{sample_name}.coffea naming convention, load all files and concatenate into the normal format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "84152965-842f-4660-91a4-eba65bc4c32c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The _out_ dictionary already exists; will use what is saved in memory if possible\n",
+      "2Mu2E_100GeV_1p2GeV_9p6mm already found in memory; not loading file\n",
+      "2Mu2E_150GeV_1p2GeV_6p4mm already found in memory; not loading file\n",
+      "2Mu2E_200GeV_1p2GeV_4p8mm already found in memory; not loading file\n"
+     ]
+    }
+   ],
+   "source": [
+    "#First check if there is already an out dictionary\n",
+    "try:\n",
+    "    out\n",
+    "    print(\"The _out_ dictionary already exists; will use what is saved in memory if possible\")\n",
+    "except NameError:\n",
+    "    print(\"WARNING! No processor output stored in the kernel's memory. Will try to load pickled coffea file for each sample instead\")\n",
+    "    out = {}\n",
+    "\n",
+    "#For each sample, try to use the data in memory if possible; if not try to load the file\n",
+    "#If those both fail, then raise an error and skip it\n",
+    "for sample in samples:\n",
+    "    if sample in out:\n",
+    "        print(f\"{sample} already found in memory; not loading file\")\n",
+    "    else:\n",
+    "        print(f\"Loading file for sample {sample}\")\n",
+    "        filename = \"output_\" + sample + \".coffea\"\n",
+    "        try: \n",
+    "            output = coffea.util.load(filename)\n",
+    "            print(\"Successfully opened file\")        \n",
+    "            out[sample] = output[\"out\"][sample]\n",
+    "        except FileNotFoundError:\n",
+    "            print(\"**** ERROR! File not found. Check the file name, or run the processor again and save the output to a pickle file using coffea.util.save\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1453be9-79e8-4e7c-8c54-537d8f0d725b",
+   "metadata": {},
+   "source": [
+    "## Test that it works by making a plot\n",
+    "\n",
+    "These lines should work whether or not you ran the processor from scratch OR if you skipped that cell and just loaded the files into memory (assuming you had made the files earlier)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "3733b82e-8a51-40e6-bc73-078af614e1c0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7ffb8c508160>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAa0AAAHLCAYAAAB7+8dwAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAHsQAAB7EBBsVhhgAAiypJREFUeJzt3Xl8TNf7B/DPvTOTTXZLNklpKRJLKKGWxB5LK0pof5aGNtrSaKuotvptRRe1dRFb0aJUa6ny1QpJES1fEmnQ2tKigsiCECEhmbnP748xV25mJptEZuJ5v17zknvuuXfOvTPuM+fcc88RiIjAGGOMWQGxpgvAGGOMlRcHLcYYY1aDgxZjjDGrwUGLMcaY1bCKoFVQUIDevXvD3t4egiDIL7VaDXd3dyxfvtzkds7Ozor8giDAxsbGZN7OnTsb5RUEwShfYWEhnn76adja2kIURTmfKIqwt7fHc889B51OV6XHzxhjTE+w9N6Dy5cvx8svv4yyiunk5IQLFy7AxcVFTnN2dkZeXp5R3jt37hgFLxcXF9y4ccMob/H33b17N3r37l1mWQRBQEJCAoKDg0vNxxhjrGIsuqa1e/duvPTSS0ZBQqVSQa1WK9Ly8vLg6+tbrv3GxMQYpZkKWMXdvHkTffv2NSqLjY0NVCqVIo2I0LNnT+Tm5pZZloMHD6J+/fpQqVSKGmT//v3lPKNHj4YgCHB3dy9zf1WloKAAgiDA29v7vvdVE+VnjNVOFh20Bg8erFj29fVFfn4+tFotioqKcPr0aTg6Osrr8/LyMHTo0DL3+/333yuW//zzzzK3+fDDDxXNfoYAdufOHWi1WmRkZMDHx0der9PpMGXKlFL3+eKLL+LJJ5/ElStX4OrqiubNm8PHxwc6nQ47duxA69atAQBNmjRB27Zt8fHHH5dZzqqyZMkSAEDbtm0rvG2LFi3w3HPPycs1UX7GWC1FFur9998nAPLLx8fHZL7r168r8jk7O8vrnJycFOsMrzp16ij2ERERIa8TBEGR16BNmzaKPOYU375p06Zm8x0+fJgAkFqtprS0NMW6tLQ0o/d/0Lp160YAaM2aNRXabu/evQSA2rRpUz0FY+wh4+npSS1atDC5zt7enho1amSUnpeXRy1atFBcj5ydnemXX34x+z7BwcEmr5clX8HBweUq9+eff04AyMvLy2weW1tbAkCnT58md3d3at++fZn7VbaxWZAFCxYolrdu3Woyn4uLC/r27Yt9+/YBgNmOFgCg0WhQVFSEW7duKdITEhIU+7t+/brRtnfu3JH/JiIkJSUhKCjIKN+iRYtw5swZAEBgYKDZsrzwwgsAgJkzZ8LPz0+xzs/PD7a2tor3fNBOnDgBAPi///u/Cm1n+NyeeeaZKi8TYw+b2bNnIzMzE4cPHzZaN3HiRBQUFJjczt/fHxcuXED9+vXRuXNn/Pvvv/jzzz/x1FNPISsrC/Xr1zfa5t1330Xjxo3l5cTERJw6dQoeHh7o16+fnF7ea8Ibb7yByZMnIyMjA4WFhUbX5pMnT+LOnTuoU6cOHnvsMWzcuBG9evXCzp07ERoaan7H5QqZNaD4LwS1Wl2pfZSsaT366KPy33FxcXI+jUYjpzdq1MhkTWvs2LFGvzgeeeQReu211+js2bMVLpuzszMBoFdffdXk+hMnTtDhw4eJiEilUpFKpZLX2djYkJ2dHY0dO5bUajUBIFEU6f3336fs7Gzy8fGRz5+zszPl5+fL2wqCQDY2NkbvJ4oiaTQaxXLJ8z5o0CD5/XC3xtmjRw/FNsXPj6HWW7L8RESvvvqqYl92dna0YcMGRR61Wk0ODg704Ycfyr/IAJC3t3dpp5axWsPOzo4effRRRVrz5s0V10dTNS0A5OTkpEgbPnw4AaDXX3+9XO8dFRVVoZqVKYYWqpdfftloXUhICAGgiIgIOc3JyYk8PDxK3afFBq3iFz8XF5dK7aNk0Bo/frz891NPPUVERFqtVtFsaC5oEemDRcnAVfxlZ2dHTzzxBP3www9llq1Vq1bydr6+vvThhx+SVqs1ynfnzh0CQA0aNDB5bnx9fcnR0VEOIqIoko2NjeI4evfuTUREGRkZcrAt7urVq4om2Pz8fAJAnp6eRuUVRZF8fX3Jzc1N3v/MmTOJiKhz585yWtu2bWnGjBkmyx8UFCSX19fXl+rWrStvZ/gBYPhcDP853dzcyMfHR843atSoMs8xY9Zs8+bNBMDox9zQoUOpRYsW1KJFC5NBKzU1ldRqNQ0dOlSRPn/+fAJAY8eOLdf7lxW0MjIyyMvLS/4/KggCde3aVZEnMTHRZAAlunc9Lf6j2nCNLnnLpDirCFqV/WVdMmgVv1dUv359IiKKiYmR05544olSg9bVq1epadOm5Wr3dXV1pdOnT5stW15eHjVu3NhoOycnJ5o/f76cb+nSpQSAevXqRUREW7dulfMaamJEJNdaAgIC5LRJkyYRAGrVqhUREb399tsEgP7v//5PUZYZM2YQAAoLCyOie23RAwYMkI/bUOMtHlgHDBhgFECK17BMlX/q1KnyD5E7d+7I+QyBrF+/fkREtHr1avk4V65cKecz/Fps3bq12XPLWG3QunVro2tQSeZqWgZ37tyhffv20YwZM+QgkZGRUa73Ly1oabVaUqlUBICaNGlC/fr1I3t7ewJAzZo1U+S1s7MjAHTx4kU5zXBPv/iPWSL9ddHUNUpxzOUqfQ0ofiF3dHSs1D5KBi2ie01YoigSkbJ2MG/evFKDloFWq6XZs2dT69atycnJyajzhuFV/OJtTmJiIvXu3Zvq1Kmj2NZwUe7VqxcBoKVLlxIR0ZAhQxQ1RQND0CruvffeUwQVQ1V97969inxPPPEEAaDNmzcTkXEnjPz8fNqzZ4/Rl93Ly4sA0IEDB4iI6JdffiEA1KFDBzlPyfIbypmXl6fY15o1awgANW/enIiI+vXrRwCMbsy+9dZbXNNiDwUbGxuTNZTiygpay5YtU1xXPvnkk3K/f2lBKzQ0lADQa6+9pkg3XMdSU1PltPDwcAJAoaGhcprhumuqPCqViurVq2e2XBYbtIoHgpL3Q0rKy8ujs2fPyi8DU0GrQYMGipqX4d4SALpz5065gpYpqamp8gdZ/FX8wyvL9evXqUePHvK2f/31l1xeQ62kYcOGRvs1NKWV/KANQWrfvn1ERHIzYkmGc2BgaK4rXqvat28fde7cmTw8PMje3l5x/8pg8ODBRl/E4uU31BINgak4Q21v0KBBRKTvMQWAkpOTFfkCAwMVx8RYbQWAHnvssTLzlBa0Ll68SK+//jqFhobKNSNDc35ZSgtahtsDxa+7Z8+epaFDhxKgvxVjYKg9Fb+XrlarzfbCdnZ2LrUfg8UGLVdXV8XFv7Su18UDUfGLqKmgNWjQIHk5KipKDo6GTgjmglZAQAB5eHiQh4cHhYeHmy3LuHHjFNt/+OGHivXbtm0jW1tbGjFihNl9uLi4EAD65ZdfjDoxaDQaow97xYoVBIB69uypSC8ZpAD9fbeSih8/kXEnjCZNmhAAsre3p7Zt29K4cePktmoHBwc5n7e3NwGg69evy2nFy284N6ba1A21u88//5yIzH+pzQVexmobUy0NpvKUFrSKu3jxYoVarkoLWmXd3x84cKAiv+EavXfvXtq3bx8B5h8JMtwnM8diu7xPmDABn3zyibw8btw4DB06FPb29op8R44cQXZ2trzs4OBQ6n5ff/11/Pe//wUA/Pjjj/IIF8UfDDbl7NmzcvfSzZs3Q6fTGY2EAUDxsDMAdO3aVbH866+/4s6dO0hJSTH7Xjdv3gQA9O7dGzqdDg0aNJDXFRUVwdnZWZF/3bp1AIARI0YY7cfOzg4A8PfffwOA0aghH374IQDA09MTgH4kDEmS5PcMCwvD6dOn8d5778l5i79nkyZN5LTs7GyIoigPpVVYWKgo/19//QUAePTRR42Oef/+/RAEARMmTIBOp4NWq1UMyVX8mEp+BxirrQzXp4qYMGECli5dikWLFmH8+PFyuo+PD0RRRGFh4X2Xy97eHoWFhZg8ebLJ9YMGDVIsT548GdOmTcNrr70GjUYDAJg3b57Jbcs85nKF3Bpi+FVteKnVaoqKiqLU1FQ6evQoRUREGHWzNtzIJzJd0yIik78MIiMjiaj0mlbx9Dp16hjV/mbMmGH24WSDAwcOEKDvaZOdna1YZ+iuDug7RZTsxLBp0yYC9B1GiqtXr55Rc95ff/1FwL2booYOEMW7z6alpcnnb8iQIUR0rxOG4Twamg6vXr0qb2fonQSA3n77bSIy3URZsvwjRowgQNlZhIjI19eXAMi1T0MnjE6dOinyGY7JVPMiY7VNyf+v5vKUrGkZeh0aOmAZxMXFEaDvcVwepdW0DPekNm3apEjv1q0bOTg4mOz9Z+jdrFarS23+s9rmQSKiHTt2lFoFLfkqWe01F7RMjZRhuEdkLmhdvHjRbIcLcy/DxbokQ5AB9L0Mvby8yMHBQU4zfFFLdmIICwsjwLhN2tQzVYamOMPzEQsWLJD336hRI7m7rOG1bds2Irr3VPzq1auJ6F613sbGhh5//HFyd3dXbOfu7k4XL16k06dPE6Dv4BIYGGiy/IbmCcN2jRo1UvRAMjB0wpg9e7bJY4qKijL9hWGsFrG1ta10RwzDD35fX18aPHgwtWvXTv6/Z+g4VZbSglZeXp58PQwMDKSBAweSh4cHAeYfUSr+mE+XLl3Mvq/VdsQwKN4lvayAVbJ3m7mg1alTJ0V68fbT0jpibN261ahmZ+5VWm0gPz+funTpotiXKIrk7Oys6N5dshOGoRZWvNZjGMaq5DBXhvtQf/31l5z2+OOPy++nUqmoW7ducppByU4YycnJigd7VSoV9e3bl15//XU5zZC3eIAzVX4ifW3R0AXWsL+S97gMnTBK9jA0HFNFOrcwZq0MHalKYy5opaWlkZ+fn+KaVNYwTiWV9ZxWamqq4hlLQN+yU/y5q+IM97IA0IkTJ0zmseou78Xl5eVR165djW7+qVQqcnV1pZiYGJPbmQtaixcvNqotGJSn9+DYsWONetAB+uZLPz8/oy7ljDFWUYbett99911NF+WBKc/DxRY/nxZjjD2s7O3t4enpiX///bemi/JAODs7o06dOsjIyDCbx6KnJmGMsYdZdHQ0zp07h8zMzJouSrXbvXs38vLy8O2335aaj2tajDFmwby9veHi4oKTJ0/WdFGqVd26dfHoo4/i0KFDpeazuKB15coV7Ny5E40aNeLncRhj7CFVUFCAc+fOITQ0FPXq1bu34oHcXauAmTNnVqhbOb/4xS9+8av2vtauXauIERY3IoaXlxcA/eSIjRo1AgAEBARUeD/z5883+7R2eR0/frzS71/V+7GksgB8fqt7P3x+q3c/fH6rdz9A5c6x4f0BYN++fVi2bJkcBwwsLmjZ2toCABo1aoTmzZsDANq1a1fh/Xh4eFRqu+J0Ol2l37+q92NJZQH4/Fb3fvj8Vu9++PxW736Ayp1jw/sD+qHzABjdJrK4oGUQEBBQJSeOMcaYdejQoYP896lTp0zmsbigVRXV0qpS/ATW9H4sqSxVxZKOyZLKUlUs6ZgsqSxVxZKOyZLKUlXMxQJ+TosxxpjV4KDFGGPManDQYowxZjVqbdAKDQ2t6SLUanx+qxef3+rF57f6Vdc55qDFKoXPb/Xi81u9+PxWPw5ajDHGHnoctBhjjFkNDlqMMcashsU9XGxw/PhxeUgPS3rgjTHGWPUoPi2JuRExuKbFGGPMalhsTYvHHmSMsYdL8VY1lUplMg/XtJjVKygowNSpU9G4cWM4OzsjJCQEBw8eBKCfrlwQBEyYMMHktr/88gsEQUDbtm0r9J5ff/01AgIC4OjoiNatW2P16tWK9YIgmH1NnDixUsfZvHlzHD161Cj9999/R9euXeHq6org4GD88ccfivV5eXkYNWoUPDw80KJFC8ydO9fk/tevX49BgwbB19cXrq6u6NChAxYvXozCwsJyl/HcuXMQRdHofBgMGjQInTt3Lvf+DA4ePFjhz8hg27ZtaNeuHRwdHdG8eXPMmzdPMZo4ANy8eRPvvPMOunbtCmdnZ/j5+WHw4MH43//+V6H3mjlzJhwdHZGfn2+07vLly1Cr1Vi2bFm597dkyRK0bNkSLi4uCAkJQVJSUoXKAwCbN29G586d4eTkhM6dO1dqHxalhuZ6NOuPP/4gAPTHH3/UdFGYlZg0aRJ5eXnRTz/9RMnJyTRhwgSyt7en1NRUmjFjBgmCQPXr1yetVmu0bUREBImiSIGBgeV+v61bt5JaraYFCxbQkSNHaMGCBWRra0tr1qyR8wCg2bNn0+nTp41ely9frtDxFRYW0uzZswkAHTlyRLEuNTWVHBwcaNq0aZSYmEgTJkwgFxcXunjxopynV69eFBQURHv37qXvv/+eHB0dKSYmRl4vSRKNGTOGHBwc6MMPP6TffvuNEhMTadasWeTs7EyDBg2ioqKicpe3W7du1K9fP6P0GzdukK2tLX355ZcVOv709HQKDg6u0GdkcPjwYRJFkd5//306fPgwrVq1itzc3OjDDz+U86SmplLTpk2pdevWtHr1ajp8+DDt3LmThg0bRqIo0g8//FDu9zt9+jQBMLnNsmXLSK1W05UrV8q1ry+++IJcXFxo5cqVlJycTJMnTyYHBwc6c+ZMucuzdetWcnR0pGXLltG+ffto2LBhVK9evXKXoSaZiwUctFiF6XQSbTigI51OqumiEBGRs7MzLVmyRJHWrl07mjZtGs2YMYP8/f3J3d2d4uLiFHkKCwvJ1dW1whfEp59+mp599llF2qRJk6hjx47yMgBatWpVJY5GafHixWRnZyfP4loyaE2ZMoU6d+4sL0uSRAEBATRr1iwiIjp27BgBoL///lvOM2fOHGrWrJm8vHr1arK1taWjR48avf+ePXsIAG3YsKHcZV66dCmp1WrKzs5WpK9bt45EUaSMjIxy76tbt24kCAIBqFTQmjhxouJzISL68ssvycPDQ17u0aMHde/enQoKCoy2j4iIIDc3N5PrzOnUqROFhYUZpfft25cGDBhQ7v00aNCAvvjiC0VaaGgoTZ06tdz76NixI82bN09evnHjBvXq1Yvi4+PLvY+aYi4WcPMgqzCJgB8TCRLVdEmA3NxceHt7IygoSJFer149XLx4EQBgY2ODIUOGYP369Yo88fHxsLGxQXBwsJyWlpYGQRAUzXAl0wRBQPfu3RX7ql+/vvx+VSk8PBzJycnYuXOnyfXx8fEYMGCAvCwIAvr164e4uDh5fZMmTdC0aVM5T//+/ZGamorz588DAN5//328+uqraN26tdH+u3fvju3bt+Pxxx+X027cuIFXXnkFfn5+cHZ2xoABA3Du3Dl5/bBhwyCKIn788UfFvjZt2oQePXrA09Oz3Mf/9ddf46+//jLZvGv4XBITE9GnTx+4uroiMDAQmzdvlvNotVr06dNHsV39+vWRnZ2NoqIiJCQkYM+ePViwYAHs7OyM3mP27NlYuXIlCgoK5LRDhw6he/fucHFxQcOGDTF9+nQQ3fvPMGrUKMTGxuL69etyWk5ODnbv3o3/+7//K9dxX716FdnZ2Ubf665du2L//v0A9E3fTz/9NFatWoVWrVqhbt26CAsLk7+HaWlpSExMxPDhw+XtnZyc8Ouvv6J3796KfXz11Vd4/PHH4e3tjU8//RT//vsvevToAScnJwQGBuLPP/+U9yEIArZv344BAwbAzc0NXbp0QVpaGubMmYPGjRvDzc0NU6ZMKddxVgYHLVYhRAStTv8fVKujankVvwCUxcXFBSdPnlR02jl69Cj27t2r+A//7LPPYvPmzSgqKpLTNm7ciPDwcKjVFeuPtHXrVrzyyivy8rVr17BmzRqjC0xVqF+/PgICAtCsWTOT6zMzM+Hj46NI8/HxQVZWVqnrASArKws5OTlIS0tD3759zZahf//+aNOmjbwcFhaGs2fPYu3atYiPj4eTkxP69euHnJwcAIC7uzsGDBiA77//Xt4mPz8fsbGxeO655ypw9EDTpk0REBCABg0amM0zdOhQDBkyBLt27UJoaCjCw8Oxd+9eAMDixYvx4Ycfynlv376NZcuWITAwEBqNBikpKfD09ESrVq1M7tvDwwNhYWFwc3MDAPz9998IDg5G3759sXfvXixYsADr1q3DtGnT5G2effZZSJKEn376SU7bunUr1Go1wsLCynXcrq6usLW1RVpamiL93LlzuHTpkry8f/9+LFiwAAsWLMCmTZuQmZmJnj17QqvV4vz581CpVDhy5AiefPJJNGjQAD179kRiYqJin/v378eBAwewZs0aPP3003jnnXfQp08fREVFYd26dcjKysL777+v2GbSpEkYN24cvv32W5w9exZt2rTBsWPHsH79egwfPhzz58/HkSNHynWsFVZWFW3GjBnUpEkT8vLyohdffJHy8/PN5j1x4gT17NmTXFxcKCgoiGJjY43yLFmyhNq1a0dOTk7Ut29fSk1NLVeVkFmGIq1Ez36hrdZXkbZyzY6SJNG3335Lzs7OFBgYSLdu3aIZM2ZQYGAgabVaatCgAf38889EpG8adHNzo4SEBDkPEdG5c+eMmuFMpRkcOHCAWrRoQS4uLnTixAk5HQBpNBqys7MzelWkqa2sMmg0Gtq4caMibfny5dSgQQMiIho3bhwNHDhQsb6oqIgA0Pbt2ykpKYkAKMpORNS6dWtFmYOCgoiI6LfffqM6derQrVu35LxarZb8/PwU96o2btxIgiDQhQsX5GWNRkM5OTkVPnYiUnxGBoZz8t577ynS+/fvT4MGDTLax4kTJ6hz586k0Whoz549REQ0YcIE+dgMEhMTjT4zwz3AF154gcaOHavIHxcXR6Io0rVr1+S0gQMHUt++fRXL4eHhFTrm0aNHU/Pmzen48eN0584d+uGHH0ij0ZC3t7d8TgRBUFxDL1y4QBqNhjZv3kzr168nURSpadOm9OOPP8r3PO3t7en06dPyPtzc3OjOnTtERHTlyhUCQHPmzJH3GRUVpTj3AGju3LmK9ab2sWXLlgodb0nmYkGpPzE/+ugjxMTEYMWKFXB2dsZrr72G0aNHY9OmTUZ5r127hpCQEAwcOBCzZs3Cjh07EBYWhgMHDsi/ghctWoQZM2Zg4cKFaNCgAT766CM89dRTOHHiRIV/7bKaoRKBVeMFjFlCWDVegFolVMt7VNSZM2cwduxY/P777xg5ciQWLlwIBweHe/tUqTB06FCsX78eAwcORHx8PGxtbdGtWzckJCRU+P1u3ryJyZMnY/ny5XjiiSdw4MABtGjRQpFn5syZeOaZZ4y29fb2rvD7mePu7o68vDxFWm5urlwzcHd3R2pqqtF6AHBzc5NrXenp6Yryb9myRe41OH/+fPmhzz///BP5+fmoW7euYp937txR1AqeeuopODs7Y8OGDXjzzTexadMm9OvXTy5XVerZs6diuVevXli6dKm8XFRUhOjoaMyePRuNGzdGQkKC3IPRx8cHW7duVWzfunVrRS2ha9eucm/DP//8E0eOHFHUIiVJgiRJuHDhAlxdXQHomwhHjRqF7Oxs2NraIj4+XrFNeSxYsADjxo1Dq1atQERo2bIlIiMjFb3/fH19FU23DRs2RLNmzXDixAkEBARAkiR888036Nq1KwB9l/LffvsNX3/9NT755BMAgJ+fH2xsbABA/lyLNyfXq1fPqGxNmjRRrDe1j+piNlJotVosWrQIs2bNwuDBgwEAK1euRKdOnZCenm7U5LBu3TrY2dlhxYoVUKlUCAoKQmJiIpYtW4alS5dCp9Nh1qxZWLp0KYYOHQoAePTRRzFq1CicOnUKLVu2rL6jZFVGEASoVQBAUKuqJ2hV1KFDh9CzZ0/4+Phgz549RvebDIYPH46wsDDcvn1bbhoUxbIjZMnuyzk5OejatSsuXbqEpUuXIjIy0uR+vLy8zDbrVRVPT0+je2np6enw8vIqdb2hfN7e3nB3d0dCQoJ8nwMAGjduLP+dmZkp/63VauHt7Y1du3YZlcVwwQYAOzs7hIeH44cffsCECRPwyy+/VKird0WUfJ5HpVJBq9UC0AfTvn37IjExETNnzsTkyZPliysAtGrVCunp6fjnn3/kC7WdnZ38uV29ehVXrlyR82u1WrzyyiuIiooyKscjjzwi/x0WFgYHBwds2rQJzs7OsLW1Vdx7LA9XV1ds3LgR+fn5uHXrFurXr49p06Yp3sfUs0yG4zfcOyx+r1IQBLRo0QIXLlxQpJVkKq209WXlr0pm/8ceO3YMmZmZihPdvn17uLu7m/zCxsfHIzQ0VHES+/fvL98Q3rdvH65evYqnn35aXv/II4/g999/54DFKk2SJAwfPhxPPPEEUlJSzAYsAAgODkadOnWwdetWbN26VXGDuiTD/RlAObQMoG/Pv3btGlJSUvDSSy+VK/BVlz59+mD79u3yMhFhx44dcueDPn364OzZs4raVmxsLJo2bSpf/KZOnYrPP//cqEYGAMnJyYr9+/v7IysrC46OjmjWrBmaNWsGb29vzJs3DxkZGYptR44ciUOHDmHhwoWQJEnxf78q7du3T7G8a9cu+Pv7AwA++eQTJCcnY9++fXjnnXcUAQvQX6NatmyJ119/XXG/02DmzJmKZX9/f5w+fVo+9mbNmuH8+fOIiYlRdOSwt7fHM888g++//x6bNm3CM888Y7KjR2neeustfP3113BwcED9+vUhSRI2b96suC94/vx5RQC6dOkSTp06BX9/f7Rq1QrOzs6KmpkkSfjzzz+r/cdUdTJb08rMzIQgCPIvNkAfTb29veWbvCXzBwYGKtKK3xA+f/48vLy88N133yEmJgbp6ekICgrC3Llz0bx58yo6HPawSUpKwrlz5/Dxxx8bXTSdnJwUy6IoIjw8HFOmTIGdnR26dOlitD8vLy/Y29tj1qxZcHNzQ3Z2NhYsWCCvlyQJGzduxLhx40BEOHPmjLxOrVYrfgVnZWUp1htoNBr4+flV+piLGzduHBYvXoy3334bQ4cOxcqVK3Hp0iWMHTsWgH5kmd69e+P555/HvHnzcPHiRXz00UeYM2eOvI/JkycjLi4O7du3x/Tp09GlSxfY2NggISEBCxYsQK9evZCdnQ0A6N27N9q0aYPw8HDMmjULAPDZZ5/hyJEj+PzzzxVlCwkJQcOGDfGf//wHYWFhcHR0rJJjLmnu3Lnw9PREYGAgNmzYgJ9//ln+Yb1+/Xq5WbLkZ/HYY49BrVZjxYoVGDhwIJ588km88cYbCAgIQFZWFlauXImzZ88qPqspU6agffv2eOeddzBs2DCkpqZi0qRJGDFihFG5Ro0ahdDQUNjY2GDLli0VPi5XV1e88cYbEEURLVq0wJdffgl7e3ujzhzDhw/H7NmzIUkS3n77bTRs2BCDBw+GRqPBSy+9hMjISHzxxRdo2LAhFi5ciOzsbIwbN67C5bEUZoNWTk4OHBwcjH5FOjk5KarLxfOX/FI6OTkhPz8fBQUFyMjIwIULF7Bw4UJ88skncHZ2xmeffYbu3bvj5MmTRm3d8+fPh4eHh8myhYaG8iRuDADkpq+RI0carRszZgwaNWqkSHv22WcRExODiRMnmqwh2djYYN26dXjrrbcQHByM9u3b4/vvv5fvG+Tk5KCgoEDusVVco0aN8O+//8rL06ZNU/QqM2jevDlOnjxZ4WM15fHHH0dsbCzefvttLFmyBG3atMGePXsUPzY3b96MV155BUOHDoW7uztmzJiB8ePHy+s1Gg1+/fVXxMTE4Mcff8Snn36K+vXro3379ti7dy8yMjLw2muvAdD/cI2NjcWbb76JESNGoKCgAMHBwdi1a5fR/39RFDFixAjMmTOn3F29K2PRokX46quv8MYbb6BRo0bYuHGjfJ/r4sWLSE1NVXSDN6C7vVQ7duyIY8eO4T//+Q8+/fRTpKWlwd/fH/3798fatWsVPUXbtm2L+Ph4TJ8+HQsXLoS7uzvGjRuHDz74wGj/PXv2hKenJ4qKihRNr+U1bdo05Obm4t1335X3l5CQoKgttmzZEs8//zwiIyNx+fJldO3aFRs2bIBGowGg77JvY2ODqVOn4sqVK+jYsSP27dtn9tr6oO3cudPs4xymKkcAzPcejI2NJUEQjEYRaNmypfzgYnEdO3ak999/X5G2adMmsrW1JSKizz//nADQ+fPn5fUFBQVUt25d+uqrr8rsMcIsh6EHYWV7+TFWFUrr1fkwMNWjsjap8MPFnp6eICLFMwGG5eK/4ornL+uGsJubG3x9feX1dnZ2ePTRRxVtsowxxpg5ZoNWy5Yt4enpqbgJm5SUhOvXrxt1MQX0N3zj4uIUA1HGxsbKN4Q7deqE3NxcnD59Wl5/69Yt/PPPP1Z9U5CxyggLC4NGoyn19d///remi1ktrl69Wuaxm+pmXVt89tlnZR7/5MmTa7qYFsvsPS21Wo2oqCi8++678PT0hJOTEyZOnIjw8HD4+voiLy8P2dnZ8PHxgZ2dHUaMGIHo6GhERkZi/PjxiI2Nxe7du+Wnrxs1aoQhQ4Zg6NChmDdvHpycnDBz5kzUrVtX7gLP2MNi0aJFuHXrVql5Sj5WUlu4urri2LFjpeYpT4/MRx55pEKjp1iKMWPGYODAgaXmKc/zbB988IHJe2m1XalP9E6fPh2FhYV48803kZ+fj6eeegoxMTEA9Dd3x4wZg4SEBISEhMDNzQ0JCQmIiopC37590axZM2zbtk3Ro3DNmjV44403EBkZifz8fHTv3h0JCQmwt7ev1oNkzNI0bNiwpotQY1Qq1UPduuLu7g53d/eaLobVEsjCfqqkpKTgiSeewB9//MGTQFoorY4waqGEtVGiRTxczBirfczFAh4wlzHGmNXgoMUYY8xqcNBijDFmNThoMcYYsxoWOx/I8ePH5We+OnToUMOlYYwxVt2KD0596tQpk3m4psWsXkFBAaZOnYrGjRvD2dkZISEhOHjwIAD9dOKCIJicrh0AfvnlFwiCgLZt21boPb/++msEBATA0dERrVu3xurVqxXrBUEw+5o4cWKljrN58+Y4evRohbfLy8vDqFGj4OHhgRYtWmDu3Lkm861fvx6DBg2Cr68vXF1d0aFDByxevFieV6s8zp07B1EUjc6HwaBBg+S5rCri4MGDFf6MDLZt24Z27drB0dERzZs3x7x58xSDIAD6+dHeeecddO3aFc7OzvDz88PgwYPxv//9r0LvNXPmTDg6OhpNZwMAly9fhlqtrtAULSdOnED//v3h5uaGxx9/HGvWrKlQeYo7fvw47O3tK/UdsigPfkSp0vHYg5bP0sYenDRpEnl5edFPP/1EycnJ8uysqamp8uyu9evXNxpHk4goIiKCRFGs0BhuW7duJbVaTQsWLKAjR47QggULyNbWltasWSPnAUCzZ8+m06dPG70uX75coeMrLCyk2bNnmxxnLz8/n+zt7Y1m2p0xY4acp1evXhQUFER79+6l77//nhwdHeWZeIn0Mz6PGTOGHBwc6MMPP6TffvuNEhMTadasWeTs7EyDBg2ioqKicpe3W7du1K9fP6P0GzdukK2trWKG4/JIT0+n4ODgSo2zd/jwYRJFkd5//306fPgwrVq1itzc3OjDDz+U86SmplLTpk2pdevWtHr1ajp8+DDt3LmThg0bRqIo0g8//FDu9zt9+jQBMLnNsmXLSK1W05UrV8q1r3PnzlG9evVoypQpdPDgQfm7bJh1uSJu375NrVu3tqqxGs3FAg5arMIsLWg5OzvTkiVLFGnt2rWjadOm0YwZM8jf35/c3d0pLi5OkaewsJBcXV0rfEF8+umn6dlnn1WkTZo0iTp27CgvA6BVq1ZV4miUFi9eTHZ2dgTA5AXnyJEjBIBSUlLo1KlT8ssQGI8dO0YA6O+//5a3mTNnDjVr1kxeXr16Ndna2tLRo0eN3n/Pnj0EgDZs2FDuMi9dupTUajVlZ2cr0tetW0eiKFJGRka599WtWzcSBIEAVCpoTZw4UfG5EBF9+eWX5OHhIS/36NGDunfvTgUFBUbbR0REkJubm8l15nTq1InCwsKM0vv27UsDBgwo936mTZtGTz31lCLtpZdeojlz5pR7HwZvvPEGtWrVqlYELW4eZFYtNzcX3t7eCAoKUqTXq1dPHsDZxsYGQ4YMwfr16xV54uPjYWNjg+DgYDktLS0NgiAomlBKpgmCYDTZZP369Y0GjK4K4eHhSE5ONjt9w6lTp+Dn54e2bdsqJiY0jN0XHx+PJk2aKKZP79+/P1JTU3H+/HkAwPvvv49XX31VMcOtQffu3bF9+3bFlO43btzAK6+8Aj8/Pzg7O2PAgAE4d+6cvH7YsGEQRRE//vijYl+bNm1Cjx495Bl1y+Prr7/GX3/9ZbJ51/C5JCYmok+fPnB1dUVgYKBiGhKtViuPf2pQv359ZGdno6ioCAkJCdizZw8WLFhgcpLG2bNnY+XKlSgoKJDTDh06hO7du8PFxQUNGzbE9OnTFcNJjRo1CrGxsbh+/bqclpOTg927d1doipb169cbTVT61VdfYerUqQD0Td9PP/00Vq1ahVatWqFu3boICwsz+h7GxcVh7dq1+Oqrr4zew7CPr776Co8//ji8vb3x6aef4t9//0WPHj3g5OSEwMBA/Pnnn/I2giBg+/btGDBgANzc3NClSxekpaVhzpw5aNy4Mdzc3DBlypRyH2dFcdBiFUJEIKkIKhSBpGp6VWCQFhcXF5w8eVLxxPzRo0exd+9eRSB79tlnsXnzZsXstBs3bkR4eDjU6or1R9q6datijqVr165hzZo1RoGzKtSvXx8BAQFmhz06deoUbG1tERoainr16iEwMBAxMTGQJAmAfnLWkmMYGpazsrKQk5ODtLQ09O3b12wZ+vfvjzZt2sjLYWFhOHv2LNauXYv4+Hg4OTmhX79+8mzP7u7uGDBgAL7//nt5m/z8fMTGxipm3S2Ppk2bIiAgAA0aNDCbZ+jQoRgyZAh27dqF0NBQhIeHY+/evQCAxYsX48MPP5Tz3r59G8uWLUNgYCA0Gg1SUlLg6emJVq1amdy3h4cHwsLC5LEA//77bwQHB6Nv377Yu3cvFixYgHXr1inmTXv22WchSRJ++uknOW3r1q1Qq9VGEziaQ0S4ePEi7ty5gwEDBsDDwwNt27Y1ule4f/9+eW63TZs2ITMzEz179oRWqwUAXLlyBWPGjMGyZcvg7e1t8r3279+PAwcOYM2aNXj66afxzjvvoE+fPoiKisK6deuQlZWF999/X7HNpEmTMG7cOHz77bc4e/Ys2rRpg2PHjsmBdv78+Thy5Ei5jrXCaqDWVypuHrRskq6Qbq9oVK0vSVdYubJJEn377bfk7OxMgYGBdOvWLXnOIa1WSw0aNKCff/6ZiPRNg25ubpSQkKCYl8jUHE2lzdt04MABatGiBbm4uNCJEyfkdACk0WiM7jXZ2dlVqKmtrDI899xz5OrqSl9//TUdOnSIvvzyS6pTp4485924ceNo4MCBim2KiooIAG3fvp2SkpIIgKLsREStW7dWlDkoKIiIiH777TeqU6cO3bp1S86r1WrJz89Pca9q48aNJAgCXbhwQV7WaDSUk5NT4WMnMj13lOGcvPfee4r0/v3706BBg4z2ceLECercuTNpNBr5vtCECRPkYzNITEw0+swM9wBfeOEFGjt2rCJ/XFwciaJI165dk9MGDhxIffv2VSyHh4eX+3izsrIIALm4uFBMTAwlJyfTl19+Sba2trRu3Tr5nAiCQKmpqfJ2Fy5cII1GQ5s3byYiokGDBtGLL76oOF/Fv0MzZswgNzc3unPnDhERXblyhQAomiCjoqIU5x4AzZ07V7He1D62bNlS7uM1xVwssNgu78xCCWqIz6dizGIJqyZU09iDQsW/lmfOnMHYsWPx+++/Y+TIkVi4cCEcHBzk9SqVCkOHDsX69esxcOBAxMfHw9bWFt26dUNCQkKF3+/mzZuYPHkyli9fjieeeAIHDhxAixYtFHlmzpyJZ555xmhbc794KyMmJgY2NjZwdnYGALRv3x43btzAggUL8Pbbb8Pd3R2pqamKbXJzcwHoRxI31LrS09MV5d+yZYvca3D+/PlyV+Q///wT+fn5qFu3rmKfd+7cQVpamrz81FNPwdnZGRs2bMCbb76JTZs2ydPeV7WSUyX16tULS5culZeLiooQHR2N2bNno3HjxkhISJB7MPr4+GDr1q2K7Vu3bq2oJXTt2lXubfjnn3/iyJEjilqkJEmQJAkXLlyAq6srAH0T4ahRo5CdnQ1bW1vEx8crtimLYXbiKVOmICoqCgDwxBNPIDU1FTExMXIzo6+vr6LptmHDhmjWrBlOnDiBq1ev4sSJEzh8+HCp7+Xn5ye/n+FzLd6cbGqamCZNmijWm9pHdeGgxSpEEAQIogY6SBBEEYJY8wPmHjp0CD179oSPjw/27NljdL/JYPjw4QgLC8Pt27flpsHyTIFRsvtyTk4OunbtikuXLmHp0qWIjIw0uR8vL69qH83c1AWlXbt2yMzMRFFRkdnJWQ3l8/b2hru7OxISEhRTwjdu3Fj+OzMzU/5bq9XC29sbu3btMnpfwwUb0E/wGh4ejh9++AETJkzAL7/8UqGu3hWhUqmMlg3NY3fu3EHfvn2RmJiImTNnYvLkyYrp6lu1aoX09HT8888/8oXazs5O/tyuXr2KK1euyPm1Wi1eeeUVOZAU98gjj8h/h4WFwcHBAZs2bYKzszNsbW0xYMCAch+Tq6sr7OzsjO4zBgQEKOZZK3nsxY9///79+Pfff1G/fn0AkJvdg4KC0LVrV/kzFATj/8Om0kpbX1b+qsT3tJhVkyQJw4cPxxNPPIGUlBSzAQsAgoODUadOHWzduhVbt241usldnOH+DKB84BHQt+dfu3YNKSkpeOmll8oV+KqDJEno2LEjFi5cqEg/fvw4mjRpAo1Ggz59+uDs2bOK2lZsbCyaNm0qX2SnTp2Kzz//3KhGBgDJycmKiWD9/f2RlZUFR0dHudOHt7c35s2bh4yMDMW2I0eOxKFDh7Bw4UJIkoSnn366Kg9ftm/fPsXyrl274O/vDwD45JNPkJycjH379uGdd95RBCxAf7+uZcuWeP311xX3Ow1mzpypWPb398fp06cVnV7Onz+PmJgYRUcOe3t7PPPMM/j++++xadMmPPPMMyY7epSmc+fOSEpKUqQdPnxY8UPo/PnzipnfL126hFOnTsHf3x+zZs3C8ePHceTIERw5ckT+HNevX4+VK1dWqCyWhGtazKolJSXh3Llz+Pjjj40umk5OToplURQRHh6OKVOmwM7ODl26dDHan5eXF+zt7TFr1iy4ubkhOzsbCxYskNdLkoSNGzdi3LhxICKcOXNGXqdWqxW/trOyshTrDTQaDfz8/Cp9zMWPp2fPnnj33XchCAI6d+6MP/74Ax9//DG+/PJLAPpf5r1798bzzz+PefPm4eLFi/joo48wZ84ceT+TJ09GXFwc2rdvj+nTp6NLly6wsbFBQkICFixYgF69eiE7OxsA0Lt3b7Rp0wbh4eGYNWsWAP1MvEeOHMHnn3+uKF9ISAgaNmyI//znPwgLC4Ojo+N9H7Mpc+fOhaenJwIDA7Fhwwb8/PPPci1i/fr1crNkyc/iscceg1qtxooVKzBw4EA8+eSTeOONNxAQEICsrCysXLkSZ8+eVXxWU6ZMQfv27fHOO+9g2LBhSE1NxaRJkzBixAijco0aNQqhoaGwsbHBli1bKnxckyZNwrPPPgtPT0907doV8fHxWLVqFX755RdFvuHDh2P27NmQJAlvv/02GjZsiMGDB0Oj0Sh6ahqCZuPGjavk+1dj7utOWTXgjhiWz5Ke09q4caP8DFPJ15gxY4xu4O/bt48A0MSJE+W0knl++uknatq0KTk5OVGPHj3o77//lm9gX7582ez7NWrUSN6HuTwAqHnz5hU+TnMdMbRaLb377rvk6+tL9vb2FBgYSN99950iz40bN2jEiBFUv359atasGc2bN89o/zqdjr744gvq1q0bubi4UJMmTei5556jf/75h3777TfF+cnOzqZRo0aRl5cXubq60qBBgxTPgRX31ltvVclN+dI6Ynz33XcUHBxMTk5O1KpVK9q4caOcp06dOmY/h+IyMjIoMjKSAgICyNHRkYKCguiDDz6gwsJCeuGFF+iLL76Q8+7atYs6depEjo6O5OfnR++9957Jh6+1Wi15eXlRvXr1KvRwdnHr1q2jtm3bkqOjIz3xxBO0detWxTlp06YNLV68mJo2bUqurq701FNPUVpamsl9meuIUfK8lvy8SuYpa72pPJVhLhZY7CSQ3377LZo3bw6Axx60NDwJJLMEaWlpaNSoEY4cOaLokv+wiI6OxpYtW8rsaGFNSo49+Pzzz/MkkIwxxqyXxQatgIAAdOjQgWtZrFYKCwuDRqMp9VW8l1htcvXq1TKP3VSvyNris88+K/P4J0+eXNPFrBGGa36HDh0QEBBgMg93xGCsBixatAi3bt0qNU/JkSxqC1dXVxw7dqzUPOXpkfnII49UaPQUSzFmzBgMHDiw1DzleZ7tgw8+wAcffFBVxbIaHLQYqwENGzas6SLUGJVKVe3Pr1kyd3d3uLu713QxrJbFNg8yxhhjJXFNi5WbJBEk0vceBO79CwCiAIgWMDoGY6x246DFykWSCFErJeTcvJc2ZonhkRfA3RFYOFbkwMUYq1YctFi5SATk3ARWTxBBRBizhLBqvAC1SoBOAiIWS5CI25sZY9WLgxarEJUIAAIAglol3H242Pp6cDHGrBP/MGaMMWY1OGgxq1dQUICpU6eicePGcHZ2RkhICA4ePAhAP9SNIAgmp2sHgF9++QWCIKBt27YVes+vv/4aAQEBcHR0ROvWrY1mlBUEwexr4sSJVXJsBr///ju6du0KV1dXBAcH448//lCsz8vLw6hRo+Dh4YEWLVpg7ty5Jt9r/fr1GDRoEHx9feHq6ooOHTpg8eLF8rxa5XHu3DmIomh0PgwGDRokz2VVEQcPHqzwZ2Swbds2tGvXDo6OjmjevDnmzZsnz49lcPPmTbzzzjvo2rUrnJ2d4efnh8GDB+N///tfhd5r5syZcHR0NJrOBgAuX74MtVpdqSla8vPz0bx5c3kg5PK6efMmoqKi4OPjg/r162PUqFHIysqq8PtblPsa0bAaGAZJ/PbbbykpKYmSkpJqukiMlIPklhwwt6YH0J00aRJ5eXnRTz/9RMnJyTRhwgSyt7en1NRUeXbX+vXrk1arNdo2IiKCRFE0GvCzNFu3biW1Wk0LFiygI0eO0IIFC8jW1pbWrFkj5wFAs2fPptOnTxu9Ll++XCXHRkSUmppKDg4ONG3aNEpMTKQJEyaQi4sLXbx4Ud5Hr169KCgoiPbu3Uvff/89OTo6yjPxEulnfB4zZgw5ODjQhx9+SL/99hslJibSrFmzyNnZmQYNGlShAV+7detG/fr1M0q/ceMG2draKmY4Lo/09HQKDg6u0GdkcPjwYRJFkd5//306fPgwrVq1itzc3OjDDz+U86SmplLTpk2pdevWtHr1ajp8+DDt3LmThg0bRqIo0g8//FDu9zt9+jQBMLnNsmXLSK1W05UrVyp8HC+99BIBUAzcWx4jR46kFi1a0K+//kr/+9//qEuXLtS1a9cKv/+DYrjmJyUl0bfffmtywFwOWqxcLDloOTs705IlSxRp7dq1o2nTptGMGTPI39+f3N3dKS4uTpGnsLCQXF1dK3xBfPrpp+nZZ59VpE2aNIk6duwoLwOgVatWVeJolEo7NiKiKVOmUOfOneV1kiRRQEAAzZo1i4iIjh07RgAUo7DPmTOHmjVrJi+vXr2abG1t6ejRo0bvv2fPHgJAGzZsKHeZly5dSmq1mrKzsxXp69atI1EUKSMjo9z76tatGwmCQAAqFbQmTpyo+FyIiL788kvy8PCQl3v06EHdu3engoICo+0jIiLIzc3N5DpzOnXqRGFhYUbpffv2pQEDBpS/8Hdt2bKFvLy8qG7duhUKWrdv3ya1Wk3//e9/5bSjR48SADp79myFy/EglCdoWWzzII89aJmICFSkhajTgoruvUou39erAkPz5ObmwtvbG0FBQYr0evXqyTP22tjYYMiQIVi/fr0iT3x8PGxsbBAcHCynpaWlQRAEHD161GyaIAhGk03Wr1/faIbg+1WeY4uPj1fMiCsIAvr164e4uDh5fZMmTRTTp/fv3x+pqak4f/48AOD999/Hq6++ajRLLgB0794d27dvV0zpfuPGDbzyyivw8/ODs7MzBgwYgHPnzsnrhw0bBlEU8eOPPyr2tWnTJvTo0UMxx1NZvv76a/z1118mm3cNn0tiYiL69OkDV1dXBAYGYvPmzXIerVaLPn36KLarX78+srOzUVRUhISEBOzZswcLFiwwOUnj7NmzsXLlShQUFMhphw4dQvfu3eHi4oKGDRti+vTpiu/sqFGjEBsbi+vXr8tpOTk52L17N/7v//6v3McOABkZGRg3bhxWrlxpND9cdHQ0nn76aaxatQqtWrVC3bp1ERYWJn83ioqKIEkS6tSpI29jmNPs9u3bin189dVXePzxx+Ht7Y1PP/0U//77L3r06AEnJycEBgbizz//lPchCAK2b9+OAQMGwM3NDV26dEFaWhrmzJmDxo0bw83NDVOmTKnQcRqUZ+xBi61p8XxalsVQmyosKKSLTYOq9SUVVm7uIYMjR47IzVCGuX7i4+PJzc2NCgsL5XxjxoyhCRMmKOYDMjXnkLm5rAxycnKoRYsW9Mwzz8hpqKKaVmnHRkTk4eFBK1euVOT57LPPyN/fn4iIpk2bRiEhIUblBUBJSUl09epVAkA7duwodxm6d+9Offr0ob1799LBgwdp+PDh1KxZM7p69aqcZ/DgwRQcHCwv37p1i+zt7Wn58uUVPGK90ubT8vHxocWLF1NycjK99dZbJAgCJSQkmNxPQUEBde/endq2bUtERPPnzydPT89ylyM1NZXs7Ozo448/psOHD9OPP/5IjRo1oqlTp8p5Ll++TGq1mr755hs57ZtvviE7Ozu6ceNGud9LkiTq06cPvfbaa0RE1KhRI0VNa8aMGeTm5kZt27al3bt30+7duykoKIiaNm0qN+cOHDiQevbsSVlZWZSbm0sjRoygJk2akCRJin1ERETQwYMH5WbIxx57jDZt2kT//e9/ydPTU1FzBECPP/44bd68WV7v4uJCo0ePpsTERHkfhw8fLvexmmIuFnDQYuUiB60iHRUWFNL/zb9NhQWFJBUWGS3f90uqXDOjJEn07bffkrOzMwUGBtKtW7fogw/epzbNfKio8A41aNCAfv75ZyLSNw26ublRQkLCfQWtAwcOUIsWLcjFxYVOnDghpwMgjUZDdnZ2Rq+KNLWVdmxERBqNRjHpIRHR8uXLqUGDBkRENG7cOBo4cKBifVFREQGg7du3U1JSEgFQlJ2IqHXr1ooyBwUFERHRb7/9RnXq1JHfn0g/2aGfn5/iXtXGjRtJEAS6cOGCvKzRaCgnJ6fCx05UetB67733FOn9+/enQYMGGe3jxIkT1LlzZ9JoNLRnzx4iIpowYYJ8bAaJiYlGn5nhHuALL7xAY8eOVeSPi4sjURTp2rVrctrAgQOpb9++iuXw8PAKHfNnn31GAQEBctOkqaAlCIJ8f5OI6MKFC6TRaGjz5s1ERHTlyhVyc3MjACQIAmk0GkUzsCFo3blzR84PgObMmSPniYqKMpoEcu7cuYr1pvZRXZNAWmzzILNMgiBA0KghqdQQNPdeJZfv6yVUfFSNM2fOICQkBM8//zyefvpp7NmzBw4ODgAIyL8MlUrA0KFD5SbC+Ph42Nraolu3bpU6Dzdv3sTLL7+Mzp07o06dOjhw4ABatGihyDNz5kwcOXLE6NWvX78qOjb94Kt5eXmK/Lm5ufIo4ebWA/qRxA0jyaenpyvybNmyRS7v6NGj5R6Ef/75J/Lz81G3bl3Y29vD3t4ejo6OuHDhAtLS0uTtn3rqKTg7O2PDhg0A9E2Dhmnvq1rPnj0Vy7169cKJEyfk5aKiIrz33nto3bo1Ll++jISEBLl518fHx+jYW7durfi8HB0d5d6Gf/75J9asWSMfu729PZ566ilIkoQLFy7I+xg1ahR27dqF7Oxs5ObmIj4+vkJNg8ePH8eMGTOwbt06k82WBr6+voqm24YNG6JZs2Y4ceIEbty4gZ49e6Jz587YtGkTfv75ZwwfPhxhYWFy0zAA+Pn5wcbGBgBQt25dAFA0J5uaJqZJkyaK9ab2UV344WJm9Q4dOoSePXvCx8cHe/bsMbrfZGD4D3v79m1s3LgR4eHh5ZoCo2T35ZycHHTt2hWXLl3C0qVLERkZaXI/Xl5e9z2aeVnH5unpaXQvLT09HV5eXqWuN5TP29sb7u7uSEhIQO/eveU8jRs3lv/OzMyU/9ZqtfD29sauXbuMyurq6ir/bWdnh/DwcPzwww+YMGECfvnll0p19S4PlUpltKzVagEAd+7cQd++fZGYmIiZM2di8uTJ8sUVAFq1aoX09HT8888/8oXazs5O/tyuXr2KK1euyPm1Wi1eeeUVREVFGZXjkUcekf8OCwuDg4MDNm3aBGdnZ9ja2iruPZYlOTkZeXl56Nixo5x2584dTJkyBW+//TZu3rxp8tiLH//PP/+MjIwM/PHHH1Cr9Zf6AQMGoG3btli3bh3efvttADD5I7GsH44l11fmh2ZlcU2LWTVJkjB8+HA88cQTSElJMRuwACA4OBh16tTB1q1bsXXrVgwfPtxs3pycHPnv4lOAA8CkSZNw7do1pKSk4KWXXipX4KuM8hxbnz59sH37dnmZiLBjxw6580GfPn1w9uxZpKamynliY2PRtGlT+SI7depUfP7554o8BsnJyYr9+/v7IysrC46OjmjWrBmaNWsGb29vzJs3DxkZGYptR44ciUOHDmHhwoWQJAlPP/30fZ0Pc/bt26dY3rVrF/z9/QEAn3zyCZKTk7Fv3z688847ioAF6DultGzZEq+//jqKioqM9j1z5kzFsr+/P06fPi0fe7NmzXD+/HnExMQoakT29vZ45pln8P3332PTpk145plnSq0xlfTMM8/g5MmTihqft7c3pk6diiNHjsjB6vz584oa3qVLl3Dq1Cn4+/vLnUdMBZiy5nKzZFzTYlYtKSkJ586dw8cff2x00SzZ20oURYSHh2PKlCmws7NDly5djPbn5eUFe3t7zJo1C25ubsjOzsaCBQvk9ZIkYePGjRg3bhyICGfOnJHXqdVqxa/trKwsxXoDjUYDPz+/+z62Bg0aYNy4cVi8eDHefvttDB06FCtXrsSlS5cwduxYAPpeuL1798bzzz+PefPm4eLFi/joo48wZ84ceV+TJ09GXFwc2rdvj+nTp6NLly6wsbFBQkICFixYgF69eiE7OxsA0Lt3b7Rp0wbh4eGYNWsWAP1MvEeOHMHnn3+uKGNISAgaNmyI//znPwgLC5N7rlW1uXPnwtPTE4GBgdiwYQN+/vlnuSa4fv16uVmy5Gfx2GOPQa1WY8WKFRg4cCCefPJJvPHGGwgICEBWVhZWrlyJs2fPKj6rKVOmoH379njnnXcwbNgwpKamYtKkSRgxYoRRuUaNGoXQ0FDY2Nhgy5YtFTomZ2dnODs7K9I0Gg08PDyMau/Dhw/H7NmzIUkS3n77bTRs2BCDBw9GTk4O3nnnHQwZMgSRkZGwsbHB999/j1OnTmHNmjUVKo9Fua87ZdWAO2JYJkt9Tmvjxo2GoeaNXmPGjKEPPvgPtfG1IUmn7zW4b98+AkATJ06U91HyJv9PP/1ETZs2JScnJ+rRowf9/fffckeMy5cvm32/Ro0ayfswlwcANW/evEqOzWDv3r305JNPkrOzM3Xr1o1SUlIU+7lx4waNGDGC6tevT82aNaN58+YZvZdOp6MvvviCunXrRi4uLtSkSRN67rnn6J9//qHffvtNcX6ys7Np1KhR5OXlRa6urjRo0CDFc2DFvfXWW1VyU760jhjfffcdBQcHk5OTE7Vq1UrRMaVOnTpmz2FxGRkZFBkZSQEBAeTo6EhBQUH0wQcfUGFhIb3wwguKDhC7du2iTp06kaOjI/n5+dF7771n8uFrrVZLXl5eVK9evQo9nG2OqY4Ybdq0ocWLF1PTpk3J1dWVnnrqKUpLS5PzHD9+nAYNGkT169cnV1dX6tWrF+3fv1+xj5LnteTnVTJPWetN5akM7j3I7oulBq2ySLpCur2ikRy0WO1R1qMItZ2pYFGbcO9BxhhjVs9ig9bx48dx6NAho5vg7MGQJMLGgxIkiacdqQ5hYWHQaDSlvv773//WdDGrxdWrV8s8dlPdrGuLzz77rMzjnzx5ck0Xs0YYrvmHDh3C8ePHTebhjhjMJImAHxMJz3QQLPeXjRVbtGhRmT24DM9Q1Taurq44duxYqXnK0yPzkUceqdCQX5ZizJgxGDhwYKl5yvM82wcffIAPPvigqoplNSw2aAUEBKBdu3Y1XQzGqkXDhg1rugg1RqVS3ffza9bM3d0d7u7uNV0Mi1R8rFlTz6ABFtw8yBhjjJXEQYsxxpjV4KDFGGPManDQYowxZjU4aDHGGLMaZQat6OhoNG3aFN7e3oiMjFTM4FnSyZMn0atXL7i6uqJjx47YsWNHlRaWMcbYw63UoPXRRx8hJiYGc+fOxdq1a3Hw4EGMHj3aZN5r164hJCQEfn5+iIuLw8CBAxEWFoaUlBQ5z3/+8x/FPDSGl2GuGsaqAkk6kFQkv/RphmX+rjFmzcw+p6XVarFo0SLMmjULgwcPBgCsXLkSnTp1Qnp6utGDj4bJylasWAGVSoWgoCAkJiZi2bJlWLp0KQDg2LFjGDlyJKZOnarY1lx/fMYqiiQdCjd0A24pR0UvWh2g/6OOF2yG/w5B5O8cY9bIbE3r2LFjyMzMVExc1r59e7i7u5ucAC4+Ph6hoaGKANS/f3/ExcXJy6dOnUKXLl0Uc9E8zA8ZsuogAbcyYBNxAjZj/4YmQj8UjCbiOGwiTtwNZlLNFpExVmlmg1ZmZiYEQZBnQAX0k4d5e3sjKyvLZP6StS8fHx85r1arxZkzZxAbG4tHH30U3t7eGDJkCP7555+qOhbG7hHVEEQNBFEDAPp/RYsdAIYxVk5m/xfn5OTAwcHBaAwwJycnxfTTxfOXnOTNyckJ+fn5KCgowPnz51FUVAQiwqpVq6DVajFr1iwEBwfjxIkTRmNtzZ8/Hx4eHibLFhoaitDQ0HIfJGOMMcuzc+dO7Ny50+Q6U5UjoJSg5e7ujvz8fOh0OkWTX25ursnBHN3d3ZGXl6dIy83Nha2tLezt7dG4cWNcvHgR3t7e8vTPQUFB8PX1xcaNG/HSSy8ptp08eTKPPcgYY7VYaRWQlJQUrFu3zijdbPOgp6cniAiXLl2S0wzLxZsMi+e/ePGiIi09PV3Oa2NjAx8fHzlgAYCjoyOaNm2KCxculHFojDHGWClBq2XLlvD09MT27dvltKSkJFy/fh09e/Y0yt+nTx/ExcUpuq/HxsaiT58+AIBvv/0W7du3V9TGbt++jbNnz6JFixZVcjCMMcZqN7NBS61WIyoqCu+++y62bt2K3bt344UXXkB4eDh8fX2Rl5eHM2fO4Pbt2wCAESNG4M6dO4iMjERSUhKio6Oxe/duTJgwAQDQt29fnD17FiNHjsSvv/6K/fv3Y/jw4ahfvz6GDBnyYI6WMcaYVSv14eLp06cjKioKb775JkaOHInOnTtj9erVAIDNmzejSZMmSExMBKCftCwhIQFpaWno27cvtm/fjm3btiEwMBCAvvlwx44duHHjBoYMGYJhw4bBxcUFe/bsgZ2dXfUeJWOMsVqhzD7A0dHRiI6ONkqPiIhARESEIs3f3x+7d+82u6+goCAkJCRUvJSMMcYYeMBcVgmiAAztKEAUys7LGGNViZ+2ZBUmigKGdeKIxRh78LimxRhjzGpw0GKMMWY1LLZ58Pjx4/IzXx06dKjh0jDGGKtuhw4dkv8+deqUyTxc02KMMWY1LLamFRAQwGMPMsbYQ6R4q5q5eRa5psUYY8xqcNBijDFmNThosVpOhKrt6+CvOmO1g8Xe02KsKgiiCup2bwAASJJqtjCMsfvGPz8ZY4xZDQ5ajDHGrAY3DzIFSSJIBGh1BODevzpuWWOMWQAOWkwmSYSolRJybt5LG7OEAOgDl7sjeGR3xliN4qDFZBIBOTeB1RNEEBHGLCGsGi9ArdJHKlHQj/DOGGM1xWKDFo89WHNUIgAIAAhq1b2gxRhj1YnHHmSMMVarWGxNi8ceZIyxhwuPPcgYY6xW4aDFGGPManDQYowxZjU4aDHGGLMaHLQYY4xZDQ5ajDHGrAYHLcYYY1aDgxZjjDGrwUGLMcaY1bDYETF47EHGGHu48NiDjDHGahWLrWnx2IOMMfZw4bEHGWOM1SoctBhjjFkNDlqMMcasBgctxhhjVoODFmOMMavBQYsxxpjV4KDFGGPManDQYowxZjU4aDHGGLMaFjsiBo89yBhjDxcee5AxxlitYrE1LR57kDHGHi489iBjjLFahYMWY4wxq8FBi1k9knTQpnwBknQ1XRTGWDXjoMVqAQm6w18CkGq6IIyxasZBizHGmNUoM2hFR0ejadOm8Pb2RmRkJAoKCszmPXnyJHr16gVXV1d07NgRO3bsMJv3119/hSiKyM3NrVzJGWOMPXRKDVofffQRYmJiMHfuXKxduxYHDx7E6NGjTea9du0aQkJC4Ofnh7i4OAwcOBBhYWFISUkxynv16lVERESAiKrmKFiVEwVgaEcBolDTJWGMsXvMPqel1WqxaNEizJo1C4MHDwYArFy5Ep06dUJ6ejp8fHwU+detWwc7OzusWLECKpUKQUFBSExMxLJly7B06VJF3sjISNStWxeXLl2q+iNiVUIUBQzrxBGLMWZZzNa0jh07hszMTAwYMEBOa9++Pdzd3bFr1y6j/PHx8QgNDVU8ENa/f3/ExcUp8i1fvhzHjx/HrFmzqqL8jDHGHiJma1qZmZkQBAFeXl5ymiAI8Pb2RlZWlsn8gYGBijQfHx9F3r///htTp05FXFxcqffGGGOMMVPMBq2cnBw4ODhAFJWVMScnJ1y5csVkfkdHR6O8+fn5KCgogFqtxogRIzBlyhQEBQVh7969pRZs/vz58PDwMLkuNDQUoaGhpW7PGGPMsu3cuRM7d+40uc5U5QgoJWi5u7sjPz8fOp1O0eSXm5sLNzc3k/nz8vIUabm5ubC1tYW9vT3ee+892NnZ4Z133inXwUyePJnHHmSMsVqstApISkoK1q1bZ5Ru9p6Wp6cniEjRWcKwXLzJsHj+ixcvKtLS09PlvPv370diYiIcHR1hb2+Pvn37AgA8PDzwwgsvlOPwGGOMPezM1rRatmwJT09PbN++HS+//DIAICkpCdevX0fPnj2N8vfp0weffvqpomYWGxuLPn36AAC+/fZb5Ofny/mTkpLw/PPP4/fff0fDhg2r9KAYY4zVTmaDllqtRlRUFN599114enrCyckJEydORHh4OHx9fZGXl4fs7Gz4+PjAzs4OI0aMQHR0NCIjIzF+/HjExsZi9+7dSExMBAD4+voq9p+ZmQkAePzxx+Hi4lKNh8gYY6y2KPXh4unTpyMqKgpvvvkmRo4cic6dO2P16tUAgM2bN6NJkyZyUHJzc0NCQgLS0tLQt29fbN++Hdu2bTPqUcgYY4xVVpmTQEZHRyM6OtooPSIiAhEREYo0f39/7N69u1xvHBISwiNiMMYYqxCLnbmYsdLopyGR7v5dJP8rgEfxYKw246DFrA5JOhRu6AbcylCkF60O0P9Rxws8gQFjtRMHLWaFJOBWBmwiTgCiGiQVoWh1ADQRxyGIGgAiBFFV5l4YY9aHgxazXqL6bpDSE0SNYpkxVvtYbNA6fvw4dDr99OkdOnSo4dIwxhirbocOHZL/PnXqlMk83PDPGGPMalhsTSsgIIDHHmSMsYdI8Va14mPeFsc1LcYYY1aDgxZjjDGrwUGLMcaY1eCgxRhjzGpw0HqISRJh40EJksRjQDLGrAMHrYeYRMCPiQSOWYwxa8FBizHGmNXgoMUYY8xqcNBijDFmNSx2RAwee5Axxh4uPPYge0iIULV9Hfx1Zqz2s9iaFo89yMpLEFVQt3ujpovBGLtPPPYgY4yxWoWDFmMWgHQ63FiwHHT3Pi5jzDQOWoxZAomQt3AF+ElvxkrHQYsxxpjV4KDFGGPManDQYowxZjU4aDHGGLMaHLQYY4xZDQ5ajDHGrIbFjojBYw+y2oZ0OuQt+gZOr74AwczT/ow9zHjsQcYsCT+Lxdh9s9iaFo89yBhjDxcee5AxxlitwkGLMcaY1eCgxRhjzGpw0GKMMWY1OGgxxhizGhbbe5Cx2o50Orn7OxVpFf9CFPhZLsZM4KDFWA0gnQ5ZPQZDl5mtSM8IDAEAqDwbwGPPFg5cjJXAQYuxmiARdJnZ8Dq6F4JaDSrSIiMwBF5H9gICkNEmRF8L45jFmAIHrYeQJBEkArQ6fdOU4V+dVJOlejgJajUEzb3/hsX/ZowZs9j/ITz2YPWQJELUSgk5N++ljVlCAPSBy90REIWaKRtj7OFWnrEHLTZoseohEZBzE1g9QQQRYcwSwqrxAtQqfaQSBUDkqMUYs1AWG7R47MHqpRIBQABAUKvuBS3GGKsp5Rl70GKDFmO1gdlu7fwbgbFK4aDFrAJJOuiOxEAVOLGmi1Ju5enWzjcQGasYDlrMSkjQHf4SqsBXa7og5VdKt3ZBo+YHiBmrBA5ajFUzU93auWs7Y5XDYw8yxhizGmUGrejoaDRt2hTe3t6IjIxEQUGB2bwnT55Er1694Orqio4dO2LHjh2K9efOnUNYWBjq1q0LLy8vRERE4PLly/d/FIwxxh4KpQatjz76CDExMZg7dy7Wrl2LgwcPYvTo0SbzXrt2DSEhIfDz80NcXBwGDhyIsLAwpKSkAAAkScKgQYNw8+ZN/Pzzz/j+++9x9OhRjBgxouqPijHGWK1ktmFdq9Vi0aJFmDVrFgYPHgwAWLlyJTp16oT09HT4+Pgo8q9btw52dnZYsWIFVCoVgoKCkJiYiGXLlmHp0qVITk7GX3/9hXPnzuGRRx4BAHz22Wfo1asXcnJy4O7uXn1HyRhjrFYwW9M6duwYMjMzMWDAADmtffv2cHd3x65du4zyx8fHIzQ0VPFAWP/+/REXFwcAuHPnDvr16ycHLADw8PAAANy+ffv+j4QxxlitZzZoZWZmQhAEeHl5yWmCIMDb2xtZWVkm85esffn4+Mh5u3XrhtjYWAAAESEzMxPz5s1D+/bt4e3tXSUHwxhjrHYz2zyYk5MDBwcHiKIyrjk5OeHKlSsm8zs6Ohrlzc/PR0FBAezt7eX0kJAQ/P7776hTpw72799v8v3nz58v18RKCg0NRWhoqPmjYowxZvF27tyJnTt3mlxnqnIElBK03N3dkZ+fD51Op2jyy83NhZubm8n8eXl5irTc3FzY2toqAhYArF27Funp6fjmm28QHByMkydPGtW2Jk+ezGMPsoeHKMApKlI/QsbdYZ8Yq+1Kq4CkpKRg3bp1Rulmmwc9PT1BRLh06ZKcZlgu3mRYPP/FixcVaenp6XLec+fO4eTJkwAAPz8/PPnkk1i2bBmcnJywffv2chweY7WXoFLB+bVxPEIGY2UwG7RatmwJT09PRUBJSkrC9evX0bNnT6P8ffr0QVxcnDwHFgDExsaiT58+AICNGzdi0KBBim10Oh0KCgpgY2Nz3wfCGGOs9jMbtNRqNaKiovDuu+9i69at2L17N1544QWEh4fD19cXeXl5OHPmjNzzb8SIEbhz5w4iIyORlJSE6Oho7N69GxMmTAAAPPPMM0hPT8cbb7yBlJQUHDx4ECNHjoRGo0H//v0fzNEyq0KSDiQVyS99WhEgaWu4ZIyxmlLqAGjTp09HYWEh3nzzTeTn5+Opp55CTEwMAGDz5s0YM2YMEhISEBISAjc3NyQkJCAqKgp9+/ZFs2bNsG3bNgQGBgIAmjRpgp9//hnTp0/HN998A3t7ezz55JPYs2cP6tevX+0HyqwLSToUbugG3MpQpBetDtD/UccLPAoZYw+fMkftjI6ORnR0tFF6REQEIiIiFGn+/v7YvXu32X317NkTBw4cqEQx2cNHAm5lwCbiBCCqQVIRilYHQBNxHIKoASBCEPn+D2MPGx5qmlk2UX03SOkJokaxbFWK9xBkjFUKBy3GHhBDD0HGWOXxTQHGGGNWw2JrWsePH5e7z3fo0KGGS8MYY6y6HTp0SP771KlTJvNwTYsxxpjVsNiaVkBAAA/jxBhjD5HirWoqM6PDcE2LsSpEOh1uLFgOKjYyDGOs6nDQYqwqSYS8hSt40FvGqgkHrYeYKABDOwr82BBjzGpY7D0tVv1EUcCwThyxGGPWg2tajDHGrAYHLcYYY1aDgxazEiJUbV8Hf2UZe7jxFYBZBUFUQd3ujSod2Z0kHbQpX4Ak7p7OmLXgoMUeYhJ0h78EINV0QRhj5WSxvQd57EHGGHu48NiD7IGTJMLGgxIkfriWMVYNLLamxWMPWieJgB8TCc90EPgXEWOsQnjsQcYYY7WKxda0GLMWpNPJYw1SkfbevzzYCGNVjoMWswgk6aA7EgNV4MQq7dZe3UinQ1aPwdBlZivSMwJDAAAqzwbgwR0ZqzoctJiF0Hc/VwW+CsB6ghYkgi4zG15H90JQq0FFWmQEhsDryF4IGjUgChDMtM0zxiqOgxZjVUBQq/VByrCsUS4zxqoGd8RgjDFmNThoMcYYsxrcfsEePpIWBICkIqDYv4BoVZ1AGHsYcdBiDxERqOOFwtX+itSi1QH6P+p4wWb47xy4GLNgFhu0eOxBVtUEUQWb4b/DMEAuSUUoWh0ATcRxCBDuBjMJltZ7kXQ65C36Bk6vvsA9EVmtxmMPMlaCIKogiBr5pU/TAGL5f7+RTocbC5brHyp+ECRC3sIV8gPMjD3MLLamxWMPMot1N4g4jR9b0yVhrFbhsQcZY4zVKhy0GGOMWQ2LbR5kDwf9VPeScfdzSVtzhWKMWSwOWqzGkKRD4YZuwK0MOU3ufg4AdbzAjQGMseI4aLEaJAG3MmATcQIEutf9/G6vPn7YlzFWEgctVvNEtTz1VPGu6FZJFOAUFcnTkTBWTThoMVaFBJUKzq+Nq+liMFZr8Q0DxhhjVoODFmOMMathsc2DPPZg1ZAkwo9JhKFBAsRqvs+ikwAi/VBDWt29IYdEAdX+3pUjQtX2deh/u0k1XRgjpNV3+6ci5b88GzKrrcoz9qDFBi1WNSQCfkwkPNNBqLZqtSgA7o5AxOJ7F/4xSwiAPnC5OwILx4oWF7gEUQV1uzcAACRZUNASBag8GyCjTYgiOSNQv6zybACPPVs4cLGHksUGLR570HqIooCFY0VIpK9hjVlCWDVegFolQCfpg5lE1t0WTTqdPGCtouZTDXFYUKngsWeL4v0yAkPgdWQvIEAfzCSytMHoGbtv5Rl70GKDFrMuoli8JkdQq/RBy1Dbsmak0yGrx2DoMrMV6cVrPlXdxV1QqYyCkqDh/66M8f8CxsoiEXSZ2fA6uheCWq2o+QgaNd9jYuwB4qDFWDkJarWitiNo1Fz7YewBs+bbDKxWKd6TjzHGTOOficwiFO/Jxxhj5vDPWsYYY1ajzKAVHR2Npk2bwtvbG5GRkSgoKDCb9+TJk+jVqxdcXV3RsWNH7NixQ7H+2rVriIyMRMOGDeHm5oaBAweafYCMMcYYK6nUoPXRRx8hJiYGc+fOxdq1a3Hw4EGMHj3aZN5r164hJCQEfn5+iIuLw8CBAxEWFoaUlBQ5z4svvoj9+/dj1apV2LFjB+zt7dG9e3dcvXq1ao+KMcZYrWT2npZWq8WiRYswa9YsDB48GACwcuVKdOrUCenp6fDx8VHkX7duHezs7LBixQqoVCoEBQUhMTERy5Ytw9KlS5GTk4OffvoJsbGx6N27t7yNn58fNm7ciFdeeaX6jpIxxlitYLamdezYMWRmZmLAgAFyWvv27eHu7o5du3YZ5Y+Pj0doaKjiKeb+/fsjLi4OAJCZmYnmzZujbdu28nobGxu4uLjg4sWLVXIwjDHGajezNa3MzEwIggAvLy85TRAEeHt7Iysry2T+wMBARZqPj4+c19/fHydPnlSs37lzJ/7++28EBQUZ7W/+/Pnw8PAwWbbQ0FCEhoaaPyrGGGMWb+fOndi5c6fJdabiDFBK0MrJyYGDgwNEUVkZc3JywpUrV0zmd3R0NMqbn5+PgoIC2Nvby+larRYLFy7EtGnT0K9fPzz11FNG+5s8eTKPPcgYY7VYaRWQlJQUrFu3zijdbPOgu7s78vPz5elBDHJzc+Hm5mYyf15enlFeW1tbRcBKSUlB27ZtMWXKFEyYMAE//fSTUWBkjBUjCnCKiqzy8Q0Zs0Zmo4WnpyeICJcuXZLTDMvFmwyL5y95byo9PV2R97///S86deqEOnXqIDk5GZ9//jns7Oyq4jgYe3AecBARVCo4vzaOxzdkDKUErZYtW8LT0xPbt2+X05KSknD9+nX07NnTKH+fPn0QFxenqJnFxsaiT58+AIAbN25g5MiRCA8Px/79+43ufzFmLSwpiJBOhxsLluunTmHsIWD2npZarUZUVBTeffddeHp6wsnJCRMnTkR4eDh8fX2Rl5eH7Oxs+Pj4wM7ODiNGjEB0dDQiIyMxfvx4xMbGYvfu3UhMTAQAbN++Hbdu3cJLL72Ec+fOKd7L3d3dZJMjY6wMEiFv4Qo4jR/L82uxh0KpN5OmT5+OqKgovPnmmxg5ciQ6d+6M1atXAwA2b96MJk2ayEHJzc0NCQkJSEtLQ9++fbF9+3Zs27ZNrlFdvHgRRIQePXqgSZMmiteCBQuq9ygZqyCuwTBmmcocMDc6OhrR0dFG6REREYiIiFCk+fv7Y/fu3Sb3M2XKFEyZMqWSxWTsASteg2GMWQwe5b2WkiSCRIBWp5852PCvTqrJUjHG2P3hoFULSRIhaqWEnJv30sYsIQD6wOXuyL2nGWPWiYNWLSQRkHMTWD1BBBFhzBLCqvEC1Cp9pBIFQOSoxRizQhYbtI4fPy53n+/QoUMNl8Y6qUQAEAAQ1Kp7Qas6iQIwtKPANTnGWIUdOnRI/tvctFUWG7SYdRJFAcM6ccRijFUPiw1aAQEBPPYgY4w9RIq3qqnMPLzPg/4xxhizGhZb02KMmUdarf7fIuW/AABRsIghphirDhy0GLMmogCVZwNktAlRJGcE3ltWeTaAx54tHLhYrcRBi7G7SLpbYxEFZQ3GgvqVCCoVPPZs0T/XAH35MgJD4HVkLwSNGqTV6gOaRDwWIauVOGgxBv1Yg9eW1oU0t7si3VCDUXk2sJgnsgWVyiggCRo1BA3/d2a1H3/L2QNDkg66IzFQBU6EIFpYNUAiSHkqeB7+FaKNvVENhu8TMWYZuPcge4Ak6A5/CcByB0AU1GpFrcXwNwcsxiwDBy3GGGNWg4MWY4wxq2Gx97R47EFW3UinQ96ib+D06gs1XRTGGMo39iDXtNjD6+5Ej4bu44wxy2exNS0ee5Axxh4uPPYgY4yxWoWDFmOMMathsc2DrPYQoANJOpBwd2gkqUi/QtKWshUrF1GAU1SkxYzWwVh146DFqhVJOsx3CIH0bab8SHHR6oB7Gep4gSv8lSeoVHB+bVxNF4OxB4aDFqtmEuqKmRBHHYdKpQ9YmojjEETN3fWi5Q3pBHANhjELxUGrlhMFYGhHoeavvaIawt1CCKKmWNCyTFyDYcwycdCq5URRwLBONR2xGGOsavDNBPZQIZ0OVKSVX4B+TirDTMByPkkHbcoXIElXE8VkjJnBNS1Wq5Ucqimrx2DoMrMVeQxzZolOumL3sPQj0qsCXwXPpsiY5bDYoMVjD5afJBF+TCIMDRIg1vjNK/Oku8MlSRJB9aDq+HeHanIaPxYAoMvMhtfRvRDUasWcWVARCr/15ylIGKtBPPbgQ0Ii4MdEsvgh9Azlq+lymp0zi/83MGbxLLamxWMPWieLnp2YMWbReOxBVgMsf3Zixpj14qDFHiARPxVOBH/tGGOVxVcP9sAIogpbCl/nZkPGWKVx0GKMMWY1LLYjBmM1QtKCcG8kenlEeksdI5GxhwwHLVbrkE4n96svPuoFSn2ETQTqeKFwtb8iVR6Rvo4XbIb/zoGLsRrGQYvVKqTTlTrqhcqzgcmR2wVRBZvhv8PQ65Gkonsj0kO4G8wk8OgYjNUsDlqsSujH6JOMm9Ue9ESPEpkd9ULQqAFRuDfqRYnpR/S1KGVQsvTR6Bl72HDQYveNJB0KN3QDbmXIacUnerwqeaL+A+7zYxj1Ql7WKJcBnn6EMWtksUGLxx60JhJwKwM2ESdAIMVEj1odYfJiYA3fC2KMlaE8Yw9abNBiVkhUy30dDBM9CkQgHh2DMVZFLDZo8diDjDH2cOGxBxljjNUqFlvTYmWTJP10JFqd/pkkw786C2yN00kAkbKcgL7jniXPAcYYsywctKyUJBGiVkrIuXkvbcwSAqAPCO6OJh9HeuBEQV+WiMX3ImnJci4cK1pg4BKhavs69I0RFvgrgLGHFActKyURkHMTWD1BBBFhzBLCqvEC1Cr9xd9SajCiKGDhWFGuERYvp07SBzOJLK+dWhBVULd7AwBAEgctxiyFpV0rWAWpRMiBSq0S5JclBCwDUbxXLuBeOVXFvn2SRNh4UIJU09MaM8YsGgctVsWKN6uVn0TAj4mEKo9ZJUa9qAok6aBN+eLuKCCMsQepzCtLdHQ0mjZtCm9vb0RGRqKgoMBs3pMnT6JXr15wdXVFx44dsWPHDpP57ty5A1dXV+Tm5la+5MwiGZrVLGVgWcOoF4KZ7rOVw7MzM1ZTSg1aH330EWJiYjB37lysXbsWBw8exOjRo03mvXbtGkJCQuDn54e4uDgMHDgQYWFhSElJUeTLz8/HW2+9xQGLMcZYhZntiKHVarFo0SLMmjULgwcPBgCsXLkSnTp1Qnp6Onx8fBT5161bBzs7O6xYsQIqlQpBQUFITEzEsmXLsHTpUgDAu+++i3nz5qGoqKjk2zHGGGNlMlvTOnbsGDIzMzFgwAA5rX379nB3d8euXbuM8sfHxyM0NFTxFHP//v0RFxcnL0dFReHw4cNYuXJlVZWfMcbYQ8RsTSszMxOCIMDLy0tOEwQB3t7eyMrKMpk/MDBQkebj46PI6+3tDW9vb1y5cqXMgs2fPx8eHh4m14WGhiI0NLTMfTDGGLNcO3fuxM6dO02uMxVngFKCVk5ODhwcHCCKysqYk5OTyaCTk5MDR0dHo7z5+fkoKCiAvb19mQdQ3OTJk3nsQcYYq8VKq4CkpKRg3bp1Rulmg5a7uzvy8/Oh0+kUTX65ublwc3MzmT8vL0+RlpubC1tb2woHLMYskqQFAcYTXUK0mN6SjNV2ZoOWp6cniAiXLl2Cr68vAMjLxZsMi+e/ePGiIi09Pd1kXsasiwjU8ULhan9FqjzRZR0v2Az/nQMXYw+A2Y4YLVu2hKenJ7Zv3y6nJSUl4fr16+jZs6dR/j59+iAuLk6euBEAYmNj0adPnyouMmMPliCqYDP8d9iM/Rs2Y/+GJuI4AEATcRw2ESfuztjMz2wx9iCYrWmp1WpERUXh3XffhaenJ5ycnDBx4kSEh4fD19cXeXl5yM7Oho+PD+zs7DBixAhER0cjMjIS48ePR2xsLHbv3o3ExMQHeTyMVQt9LUpVIk1TM4Vh7CFW6sPF06dPR1RUFN58802MHDkSnTt3xurVqwEAmzdvRpMmTeSg5ObmhoSEBKSlpaFv377Yvn07tm3bZtSjkDHGGKusMkd5j46ORnR0tFF6REQEIiIiFGn+/v7YvXt3mW8aEhIiz63E2P0inQ55i76B06sv1HRRGGPVjAfMZTVOJyknsjS8yj3iu0TIW7gCVT/aLmPM0vB8WlZCkgg/JhGGBhlPOyIKwNCOgkVM+liakuW03gkiGWM1hYOWlTBM3fFMB8GoeiyKAoZ1svwLe8lyWusEkdaieLNp1Y5yz1jNsdigdfz4cbn7fIcOHWq4NKy6iGLxIEzFJou05Ka+4nOGWXBX97vNpk7jx5bs+MiYRTp06JD896lTp0zmsdigxZilMswZBgAkWXDQYqwWstigFRAQwGMP1iCSdNAdiYEqcCKP9MAYeyCKt6qpzDRp8+0CCyJJhI0HpfL3mqtWlj07L+l0oCKt/AKg/1urreGSMcaqk8XWtB5GpXW2YPeQToesHoOhy8xWpGcEhgAAVJ4NYPFdKRljlcJBi1kfiaDLzIbX0b0Q1GpQkRYZgSHwOrIXgkYNiAL3lmOsluKgxayWoFbrg5RhWaNcfpiRVit3wDQ0nwLggM6sHv8PZxXGnTTMq/FzIwpQeTZARpsQOcnQbArom0499mzhwMWsFt86YQok6UBSkWKiw3svw7QzD76ThmV1UilNzXZgEVQqeOzZAu/j++F1ZC8AwOvIXv3y0b36+4AWfw4ZM49rWkxGkg6FG7rdnR9KT57oEJAnO6wJxTupcB2hdIJKpXiYmJtNWW3CNS0LJ0n3BpAF7g0oq6uWH/IScCsDNhEnlBMdjv272ic7JJ0OfZNWgIpNIlqR9YyxhwP//LJgkkSIWikh5+a9tJIDylZLz25RDcNuBVEDQdRU/6BKEiH00DeAZGZ6keLrVdydnbGHlcUGLR57UN8klnMTWD1BBJFyQFlAH7Ae+AjokhZ0N4QZ7ntBquEHekUBTlGRNftslqQFAYp7gXoid1ZhrJx47MFaQiUCgH4Q2XsDyj5oIlDHC4Wr/eWUkve77qe1ufh0JRVFgoidQS9iqCDgwZ8Z4/MCFDs3d+8DWlrg4hHgmbWy2KD1MI09KEkkT88B3Pu3eu5bVY4gqu52wpBAUhGKVgdAE3Ecgqi5m+P+ahSGGmNlao41OZJI8fMCQHluINwNZhIsbph1HgGeWaDyjD1osUHrYVHe+1YPvpdy8ek39PRBSVVsWVMsaD28Sp4XfZoFnJdKNptyLYxZMg5aNay8960k3YONWsWn36hOpNMBEikGvdWnE0SdBCoSQZIAKtLdXa8D8WNG5SKoVHB+bVzFN+RaGLNgHLQshGXct3qwTA18W3z0hrkAspfq/9YJIlQAMtv3gIokHhSXsYcUB60HTJIIPyYRhgYJD77nn6UpNvAtCIpBb7U6QsRiCd+8IkIlAkW3tbgW1B31EndDY6eGqLr/MfT4s2DM+nDQesB4+hFjgtp40FuViuDqImHMcn26qBMxF0DkNyIklQh3R2DhWLqvYPOwfhY8mC6zZhy0WCUYd9Ko8ncQBSwcK8odUIpuC8hZCnz9sgDRRkTEYgkSWeKQLsXPjQV1/wTKN5hu/CbQ3funHNCYJeKgxSrsQXXSEMV7NSC6e49PrRIgWF6kkhU/NyRZVtAyDKZr6PiimINM0iGrTzgutQqW8/Po8MwScdBiVkv/HBsZPd9WIyOFWAnzg+mqzQY00mr1tTOJuDchq3EctKyEKABDOwpW3WGuqp7/EQX982sRi5U1GcPzbfr7XaL+UYFKdrZ4GDtp8OjwzBpY7DeSxx5UEkUBwzpZ+cWztOd/ynoQVhSws8MLGC0KRve7tLp7z7cJgqC431XZzhYPaycNxmpSecYe5P+PzCIYHoQ1VwMTVCrEBUXK60VRkJ9nUxe736XibzRjtZrF1rQeprEHGXvgLGFkfMZKKM/Yg/y79AEpz2SOteG+lSmk04GKtIqhmqhIq39e6AEr/jmU/Cykah7gkSQdtClfgKSan8iy1JotBzRmwSy2plWblHdQ3Fpx36qEsoZqepDDMZn6HADTHTiqqQTQHf4SqsBXYcnd8Co9ZiFjDwAHrWpQsueZRU7m+KCUMlQTgAf60Grxz0Ellt6Bo9T9PIQ9CxmzFNw8WA0MPc9KtjapRCg6DRheD8OFT1Df6z5t6EotaNTlDlhV2XRq+Bwq24HD3OdrfgMtSCpSzGqsf91rJrSkpkPGLBnXtJhVqGjTqakHjwWh7O2r9oHlisxqbB1Nh4zVNA5arFYpz4PHpmJPRR5YLi+rndW4GvDEkqyqcNB6iJGkg+5IDFSBE+/+2q9mD6BXWmkPHqtVgtkaU0UeWK6IMmc1lrQgQNF0eLdED+YzeVB4YklWRThoPdQebJNUdfVKK3m/q/hAu3rlm1jT3HYVUf5OGhVpOnx4cacXVhIHrSoiSaT4lV78X51lDfZd6zyoRwXKc7+rvMM/PSxNh6TTyYPwAhWf7oSH02IlWWzQsqaxB8t6/ge49yxWNT+/Wi76HmqScZOUdP8P+9bGexdVd79LOQ9ZmU2Hd5XWjPvAm3hLUfKzL88zemVNd0I6HfomfQ3SvQioLPZyxapIecYe5G9BFSjt+R+jZ7EkeqCjXpS8qJGkQ+GGbsCtDDmP3CQFAHW8cF9PQljRvYvydqOvqvtdlZ+HrLRmXAvqdVjysy/lGb1yT3ciEUIPfQNILzyoo2AWzmKDljWOPVj8OSxz91Ee/KgXJS9qEnArAzYRJ0Cge01S8i/8ynUAMNcMVBNDNZVXRT6LqrjfVWFmO2kUK4XJdQ+2E0dZn72gvneZKe90J/f2qbu7T508ESjPolx7lWfsQYsNWuz+lNkEKKphuOQKosZks1S538uChmqyXsqmw1I7aZhQsrZcXZ04KtMEWFa7eGn71AkiVAAy2/eAiiR5nzyL8sOLg1YtVJEmQMWFsrIsaKimmnK/DyWXbDo020mjxI8Lo3WStno7cVSgCRCA/NlTafdLzeyzQUoCirTAtaDuqJe4Gxo7NaDVIrtdd55F+SFWazvk7Ny5s6aL8MCQTocbC5brm1QAFG8C1EQcBwBoIo7DZuzf+tfdX+GGC6WpX+TG+1SuO/z6NKN19ztUU3Wo7PBP5b7fVayTxqiF0t3OGfpOGqMWSohaKcmjx0sSYeNByeRo8iXXxcX/KteADYGq+LK5dRCr73coac2P1F/WZy8BuDD4RZTsSGtqn1KhvlUgYpmIyG/0l6jIb0SM/kpExDL98v2OyF/a9aG0z4mVX3VdgzloWTF5yo87RchbuAJ0p+jexUSCvgnQ5AVPJW9fMjCVuk/D604RGsQm3Ftn8fetKj5ye3m3M3TSWBulf60ar8+/aryA1RNE5Ny81zJW2piFJdcpv79iKTXi0tZVEVGAyrMBMtqEyE1/GYEhuBTQBRltQsrV/EuiCl/4vAgy/EAqZZ+ZbbvjumMDfDNBha9f1u/365cFrI0S8c0rd4MWlf7DqtSylLFdhceWZCZV1zWYmwetVFn3EkSnuvAYo4Og0pi/qJVolilrnyWZu2/1sM3FVN2dNErrdVj5HokVeH+VCh57tsidLcw2AUJX7s++tH1qdYQpSwhrNCqQCOzs8AJGa0SoVQKo+ImubE9VidD5nwvcxGilyvx5Fh0djaZNm8Lb2xuRkZEoKCgwm/fkyZPo1asXXF1d0bFjR+zYsUOxvqioCBMnToSvry8aN26Mt956C5JU+568La1pqbK/Do0Uu5fgdWQvAMDryF54H98Pz8O/QspT3f05CuTvq2N4XEwug8lJGQuLzO6z+MvUOsON8VInF6wlKtrkqJNgctLJkq/i64gs62e+oFIpev6ZbP4VAIeut4Bi58Xc5KdaHYEE0ew+DTUyQaVCXFCk8ffJVFNlkbbU/1dmv/dFWuiKtHK5igq16Ju0AkWF2gcyOWhtUGXXtXIotab10UcfISYmBitWrICzszNee+01jB49Gps2bTLKe+3aNYSEhGDgwIGYNWsWduzYgbCwMBw4cEDuuj5+/HgkJCTgm2++QWFhIcaNGwdJkjBv3jx5P8ePH6/iQ6w8w4NuFX24uWRX6kOHDoF0OnR4oj2oSIu8hSvgGDka0Nz9z1COjgqHkhLhkbUJvgM/VdyDEtTqe9NZqAT9f3pJ/7GSVgvoBMX7HUpKRE7U22h1q1DeR8kak2Cjkdu0SuuiXN7uy2aPqZLntzr2U5F9lNZVPjk5GYD++17WQ8mmGNadPK6/WN7P0EXVcX4JEuoMbQmCJMem4j1VdYe/hNj6JQAaSBLhtdXA1ZsqXD2fjLp+7Y0euF84VoRQgTEpk1OSkSbYoFu77nJaeR5YLqsV4YZTA3w8Yj0kQQVBp8WcQ98gcuEokEqCm5OAmBc1Rp+FtX5/q3I/xR93KHldo/uskJiLBWavOFqtFosWLcKsWbMwePBgAMDKlSvRqVMnpKenw8fHR5F/3bp1sLOzw4oVK6BSqRAUFITExEQsW7YMS5cuRU5ODtauXYtt27ahT58+AIAvv/wS48aNw0cffQQ7O7v7OkBLRjodcsZPxaVSAoW5Lrz3LgiF8MjeBJKiAWjk3lgkFYGghX2XWyAUgiQRgA6ikw6ZbXsbvd/l2zehqusO779+A+mock09ooD/NfVF+EPUBFgZZQ3eW1zJB5Zb/4RKDdBbXUjS6R+bELSwb7IbELQgSQAkCYWbepjtqTpd8kTdV37HoT8ELDwE+dh1EuSHstUVGZNSVOGbAbMxdFYHqCSd2QeWCSVGZimll6O2SIvrXYdh9lc9AAA6QX/WZ63oDRVJuO7YALqInyDalP4DrTpGg7HkEWbK+iGQn38ZNH9+lZfb7Kdw7NgxZGZmYsCAAXJa+/bt4e7ujl27duH5559X5I+Pj0doaKjigbD+/fvjs88+AwD89ttvEEUR3bt3l9f369cPubm5SEpKQnBwcFUdU7UxBBDD37qji6Bq8yqIxLu/Os1cYoigu5oDr9Q/KjQyQPGu69p/7wCNbeULAukAoAEKV/tDUAF1ugLata3lbd0me8JmaAJQIjClJx8CBAGCrS2g0wcmwVZj9MUqbXBbQaXCgWZ+GGZh/4ksgSAATzbMgCjof9RVbPDeKrwXJmlBukJ4ZG+GpG1VrHZu/sHjez+Q7n23BVEF0haiaPd4FB7Lk/MaPRcWcQoEnaL7vbaoCHXXBkAUJaPJT83VNA0E6ECSDgJJeLfRYkA3ASSoANIC4t1aPkST31+psEB/sV+4Ag5jhkG0tVU+6Gz40XV3O0FU4ePRG7DqZf35L8y/g6sdQ9HgYCxElQi07wPSFoLUpPx/L2lBJR6qLl7bIEgQ7h53yXNa6udwt/Ziap8W9fhIGSOekHejarlvaDZoZWZmQhAEeHl5yWmCIMDb2xtZWVkm8wcGBirSfHx85LyZmZlo0KABNJp7z5k4OTnB2dlZsb87d+4A0N8fux+ZGRlI3L//vvZx4m4ZpMJCgAhSwgTg9hV5vSAC9NN8AECEVBd/HFgCldo4cJ08fgzXCwuQcjQFEAXcGtQLGccO370gaHHl9i1cSjpg/GWUdCg6dg6aAevxD07h2vUENHhyPARRBOl0uHp7POq1/g4QBUj/bIDYdHix/wgChOPHQTodboX1QebxvyCoVEg9fRoAoLax0Wfr+gRw9GiFz01WVhZSUlIqvF1xhrHFzD35/iD3U1Vl+Tv1FNxxCkeOGD8IrNURci5ISEkRTda0DOsA4HZeNpL/SKl4fxbSQcpyAmY+hpPpRZB8NMhI/v7eert6EHt+BYglvqeSBGn3y4rvN7bqv9sn0osAW1doeq0DgUD/bITQdJjiu4bDxwDSgWyHQEg5BggqSDotkHYH4h+HcOrUaeRcAFL+IKhEQCcRci9ISD4kGhdFJ2HM5Zfxx4f3ypL8h/4Wwsn0IjwFFyQnrdEHlE6tgT+S9YdepMV19S381eJJQCCABPzVqgtA+pMoOAIXkxIhaNT4yUWDR+5uJ+kkRFx9GSmf6t9PK6lQ1NwGmvmtoIIOubfd4fJRE/k3qeH//Yn0IuQnOOGazkFR/r+at5ffz/mZHPkeX/HrBezqQey+GBCEEtcZCddfmw66kmN6n/Xc4brgY/3OilHs4z5UaD86Ha7dvoWLKX8AooCCp3vh4tEUfUtNkRZXtEVIOZyiGBGlIs6dOwcAxv0oyIzvvvuO6tSpY5TepUsXeuutt4zSmzZtSnPnzlWkxcfHEwDKz8+njz/+mAICAoy28/HxocWLF8vLa9euNTR684tf/OIXvx7y19q1axUxw2wIdHd3R35+PnQ6neLXZ25uLtzc3Ezmz8vLU6Tl5ubC1tYW9vb2Jteb2l9oaCjWrl2LRo0awd7e3lzxGGOM1WIFBQU4d+4cQkNDFelmg5anpyeICJcuXYKvry8AyMvFmwyL57948aIiLT09Xc7r6emJ7OxsFBYWwuZu01Rubi5u3ryp2F+9evUwcuTISh4mY4yx2qJLly5GaWY7J7Vs2RKenp7Yvn27nJaUlITr16+jZ8+eRvn79OmDuLg4eQ4sAIiNjZV7CgYHB4OIsGfPHnn9jh074OLiYvHzZTHGGLMMZmtaarUaUVFRePfdd+Hp6QknJydMnDgR4eHh8PX1RV5eHrKzs+Hj4wM7OzuMGDEC0dHRiIyMxPjx4xEbG4vdu3cjMTERgL75cPTo0Xj11VexdOlS3LlzB5MmTcLLL78MBwcHc8VgjDHG7jHXEcPg/fffp0cffZQ8PT0pMjKSCgoKiIho1apVBIASEhLkvMePH6cePXqQi4sLBQUF0c6dOxX7KiwspFdffZV8fHzokUceobfeeot0Ol1ZRaiwGTNmUJMmTcjLy4tefPFFys/Pr/L3YHq//fYbdenShVxcXKhbt26UnJxc00WyCs2aNaMjR44o0so6lzdu3KCRI0dSgwYNqHnz5jRnzpwHWWSrYur8loXPb9ny8/NpypQp1KhRI3JycqLg4GA6cOCAvP5BfIfLDFrW5sMPP6S6devSTz/9RLt27aKAgAAaOnRoTRfLai1fvpzs7OyMXmfOnKHU1FRycHCgadOmUWJiIk2YMIFcXFzo4sWLNV1si1VYWEizZ88mAIqLannOZa9evSgoKIj27t1L33//PTk6OlJMTExNHIbFMnd+8/Pzyd7e3uh7PGPGDDkPn9+yTZo0iby8vOinn36i5ORkmjBhAtnb21NqauoD+w7XqqBVVFREnp6etGzZMjktKSmJRFHkC2klvfHGG9SvXz86deqU4lVYWEhTpkyhzp07y3klSaKAgACaNWtWDZbYci1evJjs7OzkrrzFL6plnctjx44RAPr777/lPHPmzKFmzZo9uAOwcKWd3yNHjhAASklJUXyPL1++TER8fsvL2dmZlixZokhr164dTZs27YF9hy1llJgqUdYoHqziTp06haCgIDRr1kzx0mg0iI+PV5xrQRDQr18/xMXF1WCJLVd4eDiSk5NNTtlQ1rmMj49HkyZN0LRpUzlP//79kZqaivPnz1d/4a1Aaef31KlT8PPzQ9u2bRXf43r16gHg81seubm58Pb2RlBQkCK9Xr16uHjx4gP7DteqoFXRUTxY2U6dOoWUlBS0aNECDRo0QGho6N1BYfXnu+QYlMVHQWFK9evXR0BAAJo1a2a0rqxzaW49AD7fd5V2fk+dOgVbW1uEhoaiXr16CAwMRExMjDzLBJ/fsrm4uODkyZPyAOgAcPToUezduxdBQUEP7Dtcq4JWTk4OHBwcIJYYF8bJyQlXrlwxsxUzp6CgAGlpacjLy0NMTAw2b96MunXrIiQkBGfOnEFOTg4cHR0V2/C5rpyyzqW59QD4fJfDqVOncPnyZTz77LPYsWMHXnjhBbzzzjuYM2cOAD6/FUVEWLNmDYKDg9GiRQtERkY+sO9wrZoEsqKjeLDS2djY4MKFC/Dw8ID67vhhTz75JPz9/fH111+bHQWFz3XFlXUu3d3dkZqaarQeAJ/vcoiJiYGNjQ2cnZ0B6G8b3LhxAwsWLMDbb7/N57cCzpw5g7Fjx+L333/HyJEjsXDhQjg4ODyw73CtCloVHcWDlU6lUhlV51UqFdq0aYMLFy6UOQoKK7/yjChjaj0APt/lYLh3VVy7du2QmZmJoqIiPr/ldOjQIfTs2RM+Pj7Ys2ePYtaOB/UdrlXNgxUdxYOVbvfu3WjRogUuXLggpxERTpw4gRYtWqBPnz6Kc01E2LFjhzwKCiu/ss5lnz59cPbsWcUv1djYWDRt2hSPPPLIAy+vNZEkCR07dsTChQsV6cePH0eTJk2g0Wj4/JaDJEkYPnw4nnjiCaSkpCgCFvAAv8OV6fZoyT766CNyd3enLVu20K5du8jf35+GDx9e08WySgUFBdS4cWPq0qUL/fe//6XExER68cUXqX79+pSdna14LiMpKYnGjx9PLi4udOnSpZouukU7d+5cqc9pmTuXvXv3pqCgIPrtt99o3bp15OjoqJghgemZOr9vv/02OTk50cKFCyklJYWWL19OLi4utGrVKjkPn9/SHThwgADQd999R6dPn1a8srKyHth3uNYFLSLzo3iwiktNTaWnnnqKXF1dqV69ejRo0CDFcxZ79+6lJ598kpydnalbt26UkpJSg6W1DqYuqkRln8sbN27QiBEjqH79+tSsWTOaN2/egyy21TB1frVaLb377rvk6+tL9vb2FBgYSN99951iOz6/pdu4caPZ6UPGjBlDRA/mOywQEVW8osgYY4w9eLXqnhZjjLHajYMWY4wxq8FBizHGmNXgoMUYY8xqcNBijDFmNThoMcYYsxoctBhjjFkNDlqMMVYGQRDKfEVHR9d0MUt18+ZNPProo0ZzV+l0OsyfPx8dOnSAq6sr3N3d8eSTT+KTTz5Bfn5+pd4rNjYWgiBgxowZZvP88ssvEAQBs2bNQlpaGh599FHcvHmzzH3zw8WMMVaGRYsWmV03d+5cpKWl4auvvsJLL730AEtVMVOmTMHNmzexdOlSOS0jIwPPPfccfvvtNwQHB+PJJ5+EnZ0d/ve//yE+Ph6PPPII/ve//8Hb27tC72UYhNjLywvHjh0zmeell17C8uXLkZqaiscffxwvvfQSXF1d5elizLrvsT0YY+wh9cMPPxAACg4OJp1OV9PFMSszM5NsbGzoxIkTcppOp6NWrVqRk5MT/fjjj0bb/PTTT6RSqSgoKIgkSarwe7744osEQPGeBpIkkaenJ7Vq1UpOO3bsGNnY2FBWVlap++XmQcYYq4Tz58/jlVdegaurK9asWWM0+awlWbFiBfz9/dGiRQs57dtvv8Vff/2FmJgYDBkyxGibwYMH47XXXkNSUhISExMr/J7Dhw8HAPz4449G65KSkpCZmYmhQ4fKaYZZp7/++utS92u5Z5kxxiyUJEl4/vnncf36dSxZsgR+fn6V3pcgCPjyyy+xceNGdOvWDa6urujSpQs2bdpUZeVduXIlBg8erEibO3cumjVrhlGjRpndbuLEiZgxYwa0Wq0iPS0tDc899xweeeQRuLi4oEePHvj1118VeXr27Il69eqZPI6tW7cCAMLDwxXpzzzzDFauXFn6wVS4zscYYw+5Tz75hADQ6NGj73tfAKhbt25kb29Pr7zyCn3wwQfk7+9PAGj58uX3vX/DqPc7duyQ0woLC0mlUtHLL79c4f2dPHmSXF1dqVGjRjR9+nT6z3/+Q48//jiJokgbNmxQ5H3ppZcIAP3zzz+KdH9/f2rWrJnRvn/55RcCQOfPnzf7/hy0GGOsAg4dOkQajYYaN25Mubm5970/3J3eY+vWrXLazZs3qVWrVuTp6Un5+fn3tf9vv/2WANDly5fltFOnThEAk1ODZGdn08WLFxWv4ts+/fTT1KxZM8rLy5PTCgoKqG3btuTh4aG4t/frr78SAPr000/ltNOnTxMAmj59utF7Z2VlEQBau3at2ePh5kHGGCunW7duYeTIkZAkCWvXroWzs3OV7Ldly5YYNGiQvFynTh1MnjwZmZmZSE5Ovq99//vvv7CxsUG9evXkNENXdpVKZZR/yJAhaNiwoeI1bNgwAMDt27fx888/Izw8HLm5uUhPT0d6ejquXr2KYcOGISsrC8ePH5f31b17dzRo0EDRRGhoGix+P8ugQYMGUKvV+Pfff80eDwctxhgrp0mTJuHvv//Ge++9h86dO5drmx49emD9+vWl5mndurVRWqtWrQAAZ8+eRY8ePSr9fFhWVhbc3NwUaY8//jgEQcCZM2eM8s+ePRs///yz/PL395fXnT59GkSEjz/+2Ciwvfvuu/L7GahUKgwdOhTJyck4d+4cAH3Qaty4Mdq2bWuyvO7u7op9lKQu9WgZY4wBALZs2YLly5ejU6dOeO+996p032q18aXYUAsqKirCnj175PQePXrglVdewbPPPluufQuCYJRWp04d+Pr6Yt++fUbrSgbjF154AQ0aNACgfxAZAN544w307t3b5PsZgq3B8OHDsWTJEmzevBkRERHYv38/3nzzzVLLS6U8PsxBizHGynDp0iVERkbCyckJ3333nckgY7Bx40a89957uHLlCoYPH47CwsIy93/q1CmjtL/++gsA0KRJk8oXHICHhwdycnKM0l988UV88MEH2Lx5s8ku7wCwd+9eZGdny7Wtxx57DADg5OSEgQMHKvJevHgRaWlpimZIAAgODoanpyc2bdqEevXqQafTmWwaNMjJyYGnp6fZ9dw8yBhjpSAijBkzBlevXkVMTAweffRRs3lPnDiBiIgIzJkzB2fOnEHdunXxv//9r8z3SEpKQkJCgrx869YtzJs3D/Xq1UP79u3vq/yNGjVCUVERLl++rEifOnUqfH198dJLL2HHjh1G2x07dgxjxoxRpDk6OqJ79+5Yvny5IhAWFRVhyJAhGDdunNF9MlEUER4ejoMHD2LJkiVo2LAhgoKCTJb18uXLKCoqQqNGjcweD9e0GGOsFKtWrUJ8fDx8fHyQl5dndkinoKAgxMbGYujQoQgLCwMAREdHY8WKFWW+h7e3NwYOHIgXX3wR7u7u2LhxI06cOIGlS5fC0dHxvsofHBwMAPjjjz/Qr18/Od3e3h7btm3D8OHDMWDAAHTv3h3t27eHk5MT/vzzT2zZsgWDBw9Gu3btFAFq7ty5CAkJQZs2bTB69GhIkoRt27bh1KlT2LZtm8kyDB8+HAsXLsTBgwfx+uuvm2yyBCB3OjGU2RQOWowxVgrDALPp6emYOHGi2XwzZsxAZmamojlPpVKVWmswGDJkCDp16oTPP/8cf//9NwICArBhwwa51979eOSRR/DYY4/h4MGDiqAFAG3atMEff/yB2bNnY//+/Vi+fDnq1auHdu3a4bvvvsPw4cPx5ZdfYsuWLfI27du3R3JyMt5++22sXr0a+fn5aNu2LRYuXIgePXqYLEOXLl3g7e2NS5culdo0mJiYiCZNmpT6sDYPmMsYY1Xko48+QmpqKtasWQNAP3JGw4YN8fnnn5vtOCEIAqKiohATE1Ou96hoRwwA+Pjjj7Fx40YcOXKk3NvUhDZt2uDZZ5+VeyKawve0GGOsigwbNgw//vgjtm7dihs3bmDmzJnIzs6u6WIhMjISJ06cwMmTJ2u6KGadPHkSp06dQmRkZKn5OGgxxlgVadasGVavXo1p06ahUaNG8tQfNc3DwwMTJ07EF198UdNFMevzzz/Ha6+9JnevN4ebBxljrAZVtHmwsvLy8tCmTRskJCTc1wC/1eH8+fPo3r07/vzzzzI7nnDQYowxZjW4eZAxxpjV4KDFGGPManDQYowxZjU4aDHGGLMaHLQYY4xZjf8H+oBOfD6P+BIAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 500x500 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "for sample in samples:\n",
+    "    utilities.plot(out[sample][\"hists\"][\"genAs_pt\"][channels[0], ::2j], density=True)\n",
+    "plt.legend(samples, alignment=\"left\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
We discussed in BASH today that it would be useful to be able to save coffea outputs to a file. This is useful in the event that the kernel dies or if only some of the samples process successfully each time. I added a notebook that demonstrates how to save and load these files. 

The key lines are the following 3, but the notebook also shows how to check if the files exist or if that output is already saved in memory, and how to concatenate files back together into the normal format.
`import coffea.util`
`coffea.util.save(output,out_file_name)`
`coffea.util.load(filename)`

Note: coffea output files (*.coffea) should **never** be pushed to the repo! These should be reproduced locally each time, since they don't have any sort of version history attached.